### PR TITLE
use public URL for docs

### DIFF
--- a/src/_canary/plugins/subcommands/docs.py
+++ b/src/_canary/plugins/subcommands/docs.py
@@ -19,5 +19,5 @@ class Docs(CanarySubcommand):
     description = "open canary documentation in a web browser"
 
     def execute(self, args: "argparse.Namespace") -> int:
-        webbrowser.open("http://ascic-test-infra.cee-gitlab.lan/canary")
+        webbrowser.open("https://canary-wm.readthedocs.io/en/production/")
         return 0


### PR DESCRIPTION
The docs URL opened by `canary docs` should be the public URL so this also works for non-Sandia users.