### PR TITLE
fixed typo, added @ symbol into pip install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Python 3.10+
 To install the latest development version, execute:
 
 ```console
-python3 -m pip install "canary-wm git+ssh://git@github.com/sandialabs/canary"
+python3 -m pip install "canary-wm@git+ssh://git@github.com/sandialabs/canary"
 ```
 
 To install the latest production version, execute:


### PR DESCRIPTION
There was a small typo in the README instruction that needed an extra @ symbol for pip to pick up the right URL. 