### PR TITLE
new syntax for python 3.12

### DIFF
--- a/src/_canary/finder.py
+++ b/src/_canary/finder.py
@@ -35,7 +35,7 @@ class Finder:
         special: str | None = None
         if self._ready:
             raise ValueError("Cannot call add() after calling prepare()")
-        if match := re.search("^(\w+)@(.*)", root):
+        if match := re.search(r"^(\w+)@(.*)", root):
             special, f = match.groups()
             root = os.path.abspath(f)
             if paths:


### PR DESCRIPTION
Fixed syntax on line 38 to for python 3.12, as it was giving a warning that '\w' was an invalid escape sequence. 