### PR TITLE
Add functionality for Subprojects to parse from files and tests

### DIFF
--- a/src/_canary/plugins/builtin/cdash/xml_generator.py
+++ b/src/_canary/plugins/builtin/cdash/xml_generator.py
@@ -227,8 +227,8 @@ class CDashXMLReporter:
         if use_labels:
             project_labesls = set()
             for case in cases:
-                if case.subproject_labels is not None:
-                    for sub_proj_labels in case.subproject_labels:
+                if case.keywords is not None:
+                    for sub_proj_labels in case.keywords:
                         project_labesls.add(sub_proj_labels)
             subproject_labels = list(project_labesls)
                 

--- a/src/_canary/testcase.py
+++ b/src/_canary/testcase.py
@@ -324,7 +324,6 @@ class TestCase(AbstractTestCase):
         self._family: str = ""
         self._classname: str | None = None
         self._keywords: list[str] = []
-        self._subproject_labels: list[str] | None = None
         self._parameters: Parameters = Parameters()
         self._timeout: float | None = None
         self._baseline: list[str | tuple[str, str]] = []
@@ -571,15 +570,6 @@ class TestCase(AbstractTestCase):
     @keywords.setter
     def keywords(self, arg: list[str]) -> None:
         self._keywords = list(arg)
-
-    @property
-    def subproject_labels(self) -> list[str] | None:
-        """Test subproject labels"""
-        return self._subproject_labels
-
-    @subproject_labels.setter
-    def subproject_labels(self, arg: list[str]) -> None:
-        self._subproject_labels = list(arg)
 
     @property
     def implicit_keywords(self) -> list[str]:


### PR DESCRIPTION
This adds capability for the -f option to parse Subproject labels from the build.xml for CDash.

This also adds capability for using the labels and overwriting the labesl for Subprojects from test cases on generation of CDash XML.

https://github.com/sandialabs/canary/issues/15