### PR TITLE
Move toward more abstract queue processing to accommodate distributed pool more cleanly

### DIFF
--- a/src/_canary/atc.py
+++ b/src/_canary/atc.py
@@ -111,6 +111,9 @@ class AbstractTestCase(abc.ABC):
     def refresh(self) -> None: ...
 
     @abc.abstractmethod
+    def reload_and_check(self) -> Any: ...
+
+    @abc.abstractmethod
     def command(self) -> list[str]: ...
 
     @property

--- a/src/_canary/error.py
+++ b/src/_canary/error.py
@@ -48,9 +48,12 @@ class TestTimedOut(MyException):
 
 
 class FailFast(Exception):
-    def __init__(self, *, failed):
-        self.failed = failed
-        super().__init__(",".join(_.name for _ in failed))
+    def __init__(self, failed):
+        try:
+            self.failed = list(failed)
+        except TypeError:
+            self.failed = [failed]
+        super().__init__(",".join(_.name for _ in self.failed))
 
 
 class StopExecution(Exception):

--- a/src/_canary/plugins/builtin/conductor.py
+++ b/src/_canary/plugins/builtin/conductor.py
@@ -77,7 +77,7 @@ def job_start_summary(case: "TestCase", *, qrank: int | None, qsize: int | None)
         fmt.write(datetime.now().strftime("[%Y.%m.%d %H:%M:%S]") + " ")
     if qrank is not None and qsize is not None:
         fmt.write("@*{[%s]} " % f"{qrank + 1:0{digits(qsize)}}/{qsize}")
-    fmt.write("Starting @*b{%id}: %X")
+    fmt.write("Starting test case @*b{%id}: %X")
     return case.format(fmt.getvalue()).strip()
 
 
@@ -89,5 +89,5 @@ def job_finish_summary(case: "TestCase", *, qrank: int | None, qsize: int | None
         fmt.write(datetime.now().strftime("[%Y.%m.%d %H:%M:%S]") + " ")
     if qrank is not None and qsize is not None:
         fmt.write("@*{[%s]} " % f"{qrank + 1:0{digits(qsize)}}/{qsize}")
-    fmt.write("Finished @*b{%id}: %X %s.n")
+    fmt.write("Finished test case @*b{%id}: %X %s.n")
     return case.format(fmt.getvalue()).strip()

--- a/src/_canary/testcase.py
+++ b/src/_canary/testcase.py
@@ -1445,6 +1445,11 @@ class TestCase(AbstractTestCase):
             for dep in self.dependencies:
                 dep.refresh()
 
+    def reload_and_check(self) -> Any:
+        self.refresh()
+        if not self.status.satisfies(("success", "skipped")):
+            return self
+
     @contextmanager
     def rc_environ(self, **env: str) -> Generator[None, None, None]:
         save_env = os.environ.copy()

--- a/src/canary_hpc/conductor.py
+++ b/src/canary_hpc/conductor.py
@@ -3,19 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-import atexit
-import concurrent.futures
 import io
 import os
-import signal
 import threading
-import time
 from collections import Counter
-from concurrent.futures.process import BrokenProcessPool
 from datetime import datetime
-from functools import partial
 from typing import Any
-from typing import Callable
 from typing import Sequence
 
 import hpc_connect
@@ -23,19 +16,12 @@ import psutil
 
 import canary
 from _canary.config.rpool import ResourcePool
-from _canary.error import FailFast
-from _canary.error import StopExecution
 from _canary.plugins.subcommands.run import Run
 from _canary.plugins.types import Result
-from _canary.queue import Busy as BusyQueue
-from _canary.queue import Empty as EmptyQueue
+from _canary.queue import process_queue
 from _canary.third_party.color import colorize
-from _canary.util import keyboard
 from _canary.util import logging
 from _canary.util.misc import digits
-from _canary.util.procutils import ProcessPoolExecutor
-from _canary.util.procutils import cleanup_children
-from _canary.util.returncode import compute_returncode
 from _canary.util.string import pluralize
 from _canary.util.time import hhmmss
 
@@ -167,55 +153,9 @@ class CanaryHPCConductor:
         The session returncode (0 for success)
 
         """
-        returncode: int = -10
-        atexit.register(cleanup_children)
         queue = ResourceQueue.factory(global_lock, cases, resource_pool=self.rpool)
-        nbatches = len(queue)
         runner = Runner()
-        pbar = (
-            canary.config.getoption("format") == "progress-bar"
-            or logging.get_level() > logging.INFO
-        )
-        work_tree = canary.config.get("session:work_tree")
-        assert work_tree is not None
-        with canary.filesystem.working_dir(work_tree):
-            cleanup_queue = True
-            try:
-                what = canary.string.pluralize("batch", nbatches)
-                logger.info("@*{Running} %d %s" % (nbatches, what))
-                start = canary.time.timestamp()
-                stop = -1.0
-                logger.debug("Start: processing queue")
-                process_queue(backend=self.backend, runner=runner, queue=queue)
-            except KeyboardInterrupt:
-                logger.debug("keyboard interrupt: killing child processes and exiting")
-                returncode = signal.SIGINT.value
-                cleanup_queue = False
-                raise
-            except StopExecution as e:
-                logger.debug("stop execution: killing child processes and exiting")
-                returncode = e.exit_code
-            except FailFast as e:
-                logger.debug("fail fast: killing child processes and exiting")
-                code = compute_returncode(e.failed)
-                returncode = code
-                cleanup_queue = False
-                names = ",".join(_.name for _ in e.failed)
-                raise StopExecution(f"fail_fast: {names}", code)
-            except Exception:
-                logger.exception("unknown failure: killing child processes and exiting")
-                returncode = compute_returncode(queue.cases())
-                raise
-            else:
-                if pbar:
-                    queue.update_progress_bar(start, last=True)
-                returncode = compute_returncode(queue.cases())
-                queue.close(cleanup=cleanup_queue)
-                stop = canary.time.timestamp()
-                dt = stop - start
-                logger.info("@*{Finished} %d %s (%s)" % (nbatches, what, hhmmss(dt)))
-                atexit.unregister(cleanup_children)
-        return returncode
+        return process_queue(queue, runner, backend=self.backend.name)
 
     @staticmethod
     def setup_parser(
@@ -286,59 +226,6 @@ class LegacyParserAdapter:
         return self.parser.parse_args(args)
 
 
-def process_queue(
-    *, backend: hpc_connect.HPCSubmissionManager, runner: Callable, queue: ResourceQueue
-) -> None:
-    """Process the test queue, asynchronously
-
-    Args:
-        queue: the test queue to process
-
-    """
-    futures: dict = {}
-    start = canary.time.timestamp()
-    duration = lambda: canary.time.timestamp() - start
-    timeout = float(canary.config.get("config:timeout:session", -1))
-    qsize = queue.qsize
-    qrank = 0
-    ppe = None
-    pbar = canary.config.getoption("format") == "progress-bar" or logging.get_level() > logging.INFO
-    try:
-        canary.config.archive(os.environ)
-        with ProcessPoolExecutor(workers=queue.workers) as ppe:
-            signal.signal(signal.SIGTERM, signal.SIG_IGN)
-            while True:
-                if key := keyboard.get_key():
-                    if key in "sS":
-                        logger.log(logging.EMIT, queue.status(start=start), extra={"prefix": ""})
-                    elif key in "qQ":
-                        logger.debug(f"Quiting due to caputuring {key!r} from the keyboard")
-                        ppe.shutdown(cancel_futures=True)
-                        cleanup_children()
-                        raise KeyboardInterrupt
-                if pbar:
-                    queue.update_progress_bar(start)
-                if timeout >= 0.0 and duration() > timeout:
-                    raise TimeoutError(f"Test execution exceeded time out of {timeout} s.")
-                try:
-                    iid, obj = queue.get()
-                    queue.heartbeat()
-                except BusyQueue:
-                    time.sleep(0.005)
-                    continue
-                except EmptyQueue:
-                    break
-                logger.debug(f"Submitting {obj} to process pool for execution")
-                future = ppe.submit(runner, obj, backend.name, qsize=qsize, qrank=qrank)
-                qrank += 1
-                callback = partial(done_callback, queue, iid)
-                future.add_done_callback(callback)
-                futures[iid] = (obj, future)
-    finally:
-        if ppe is not None:
-            ppe.shutdown(cancel_futures=True)
-
-
 class KeyboardQuit(Exception):
     pass
 
@@ -346,11 +233,11 @@ class KeyboardQuit(Exception):
 class Runner:
     """Class for running ``AbstractTestCase``."""
 
-    def __call__(self, batch: TestBatch, backend_name: str, *args: str, **kwargs: Any) -> None:
+    def __call__(self, batch: TestBatch, **kwargs: Any) -> None:
         # Ensure the config is loaded, since this may be called in a new subprocess
         canary.config.ensure_loaded()
         try:
-            backend = hpc_connect.get_backend(backend_name)
+            backend = hpc_connect.get_backend(kwargs["backend"])
             qrank = kwargs.get("qrank", 0)
             qsize = kwargs.get("qsize", 1)
             if summary := batch_start_summary(batch, qrank=qrank, qsize=qsize):
@@ -360,58 +247,6 @@ class Runner:
         finally:
             if summary := batch_finish_summary(batch, qrank=qrank, qsize=qsize):
                 logger.log(logging.EMIT, summary, extra={"prefix": ""})
-
-
-def done_callback(queue: ResourceQueue, iid: int, future: concurrent.futures.Future) -> None:
-    """Function registered to the process pool executor to be called when a test (or batch of
-    tests) completes
-
-    Args:
-        iid: the queue's internal ID of the test (or batch)
-        queue: the active test queue
-        future: the future return by the process pool executor
-
-    """
-    if future.cancelled():
-        return
-    try:
-        logger.debug(f"Retrieving future for Batch({iid})")
-        future.result()
-    except BrokenProcessPool:
-        # The future was probably killed by fail_fast or a keyboard interrupt
-        logger.debug("BrokenProcessPool occurred while attempting to retrieve future")
-        return
-    except BrokenPipeError:
-        # something bad happened.  On some HPCs we have seen:
-        # BrokenPipeError: [Errno 108] Cannot send after transport endpoint shutdown
-        # Seems to be a filesystem issue, punt for now
-        logger.debug("BrokenPipeError occurred while attempting to retrieve future")
-        return
-
-    # The case (or batch) was run in a subprocess.  The object must be
-    # refreshed so that the state in this main thread is up to date.
-    batch: TestBatch = queue.done(iid)
-    if not isinstance(batch, TestBatch):
-        logger.error(f"Expected AbstractTestCase, got {batch.__class__.__name__}")
-        return
-    batch.refresh()
-    logger.debug(f"Batch {batch} finished in {batch.duration} s.")
-    failed: list[canary.TestCase] = []
-    for case in batch:
-        if case.status == "running":
-            # Job was cancelled
-            case.status.set("cancelled", "batch cancelled")
-        elif case.status == "skipped":
-            pass
-        elif case.status == "ready":
-            case.status.set("not_run", "test not run for unknown reasons")
-        elif case.start > 0 and case.stop < 0:
-            case.status.set("cancelled", "test case cancelled")
-        if not case.status.satisfies(("skipped", "success")):
-            failed.append(case)
-            logger.debug(f"Batch {batch}: test case failed: {case}")
-    if failed and canary.config.getoption("fail_fast"):
-        raise FailFast(failed=failed)
 
 
 def batch_start_summary(batch: TestBatch, qrank: int | None, qsize: int | None) -> str:

--- a/src/canary_hpc/queue.py
+++ b/src/canary_hpc/queue.py
@@ -55,7 +55,10 @@ class ResourceQueue(queue.AbstractResourceQueue):
             raise ValueError("Cannot partition test cases: missing batching options")
         batches: list[TestBatch] = batch_testcases(
             cases=self.tmp_buffer,
-            batchspec=batchspec,
+            layout=batchspec["layout"],
+            count=batchspec["count"],
+            duration=batchspec["duration"],
+            nodes=batchspec["nodes"],
             cpus_per_node=kwds.get("cpus_per_node"),
         )
         if not batches:

--- a/src/canary_hpc/tests/batching.py
+++ b/src/canary_hpc/tests/batching.py
@@ -35,11 +35,11 @@ def test_batch_n(generate_files):
     cases = _canary.finder.generate_test_cases(files)
     assert len([c for c in cases if c.status != "masked"]) == num_cases
     spec = {"count": 5, "duration": None, "nodes": "any", "layout": "flat"}
-    batches = testbatch.batch_testcases(cases=cases, batchspec=spec)
+    batches = testbatch.batch_testcases(cases=cases, **spec)
     assert len(batches) == 5
     assert sum(len(_) for _ in batches) == num_cases
     spec = {"count": ONE_PER_BIN, "duration": None, "nodes": "any", "layout": "flat"}
-    batches = testbatch.batch_testcases(cases=cases, batchspec=spec)
+    batches = testbatch.batch_testcases(cases=cases, **spec)
     assert len(batches) == num_cases
 
 
@@ -52,8 +52,8 @@ def test_batch_t(generate_files):
     cases = _canary.finder.generate_test_cases(files)
     assert len([c for c in cases if c.status != "masked"]) == num_cases
     spec = {"count": None, "duration": 15 * 60, "nodes": "any", "layout": "flat"}
-    batches = testbatch.batch_testcases(cases=cases, batchspec=spec)  # 5x long test case duration
+    batches = testbatch.batch_testcases(cases=cases, **spec)  # 5x long test case duration
     assert sum(len(_) for _ in batches) == num_cases
     spec = {"count": None, "duration": 15 * 60, "nodes": "same", "layout": "flat"}
-    batches = testbatch.batch_testcases(cases=cases, batchspec=spec)
+    batches = testbatch.batch_testcases(cases=cases, **spec)
     assert sum(len(_) for _ in batches) == num_cases

--- a/src/canary_hpc/tests/binpack.py
+++ b/src/canary_hpc/tests/binpack.py
@@ -7,4 +7,18 @@ def test_binpack():
         blocks.append(canary_hpc.binpack.Block(f"a{i}", i, 1))
     bins = canary_hpc.binpack.pack_to_height(blocks, width=12, height=3)
     extents = [4, 8, 12]
-    bins = canary_hpc.binpack.pack_to_height(blocks, height=5, extents=extents)
+    bins = canary_hpc.binpack.pack_to_height(blocks, height=5, grouper=Grouper(extents))
+
+
+class Grouper:
+    def __init__(self, extents):
+        self.extents = extents
+
+    def __call__(self, blocks):
+        groups = {}
+        for block in blocks:
+            for extent in sorted(self.extents):
+                if block.width <= extent:
+                    groups.setdefault(extent, []).append(block)
+                    break
+        return list(groups.values())

--- a/tests/resource_pool.py
+++ b/tests/resource_pool.py
@@ -54,6 +54,9 @@ class Case(AbstractTestCase):
     def refresh(self) -> None:
         raise NotImplementedError
 
+    def reload_and_check(self) -> None:
+        raise NotImplementedError
+
     def run(self) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
- Remove extents from bin packing.  Closes #55 #56
- Add AbstractTestCase.reload_and_check() method.  Closes #57
- process_queue takes AbstractResourceQueue through interface.  Closes #58
