### PR TITLE
add hook for `canary init` to setup defaults in a workspace on initialization

### DIFF
--- a/src/_canary/hookspec.py
+++ b/src/_canary/hookspec.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from .select import Selector
     from .testcase import TestCase
     from .workspace import Session
+    from .workspace import Workspace
 
 
 project_name = "canary"
@@ -125,6 +126,18 @@ def canary_configure(config: "CanaryConfig") -> None:
 
     Args:
       config: The canary config object.
+
+    """
+
+
+@hookspec
+def canary_initfinish(workspace: "Workspace") -> None:
+    """Allow plugins to modify the newly initialized workspace without additional user commands/steps.
+
+    This hook is called by `canary init` just before exit.
+
+    Args:
+      workspace: The canary Workspace object.
 
     """
 

--- a/src/_canary/plugins/subcommands/init.py
+++ b/src/_canary/plugins/subcommands/init.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ... import config
 from ...hookspec import hookimpl
 from ...util import logging
 from ...workspace import Workspace
@@ -23,6 +24,11 @@ def canary_addcommand(parser: "Parser") -> None:
     parser.add_command(Init())
 
 
+@hookimpl(trylast=True)
+def canary_initfinish(workspace: Workspace) -> None:
+    logger.info(f"[bold]Finished[/] initializing canary workspace at {workspace.root.parent}")
+
+
 class Init(CanarySubcommand):
     name = "init"
     description = "Initialize a Canary session"
@@ -37,5 +43,6 @@ class Init(CanarySubcommand):
         )
 
     def execute(self, args: "argparse.Namespace") -> int:
-        Workspace.create(Path(args.path).absolute(), force=args.w)
+        ws = Workspace.create(Path(args.path).absolute(), force=args.w)
+        config.pluginmanager.hook.canary_initfinish(workspace=ws)
         return 0

--- a/src/_canary/plugins/subcommands/init.py
+++ b/src/_canary/plugins/subcommands/init.py
@@ -42,7 +42,7 @@ class Init(CanarySubcommand):
             help="Initialize session in this directory [default: %(default)s]",
         )
         parser.add_argument(
-            "--no-post-actions",
+            "-n,--no-post-actions",
             action="store_false",
             dest="post_actions",
             help="Do not run post-initialization actions on the workspace",

--- a/src/_canary/plugins/subcommands/init.py
+++ b/src/_canary/plugins/subcommands/init.py
@@ -41,8 +41,16 @@ class Init(CanarySubcommand):
             nargs="?",
             help="Initialize session in this directory [default: %(default)s]",
         )
+        parser.add_argument(
+            "--no-post-actions",
+            action="store_false",
+            dest="post_actions",
+            help="Do not run post-initialization actions on the workspace",
+        )
+        parser.set_defaults(post_actions=True)
 
     def execute(self, args: "argparse.Namespace") -> int:
         ws = Workspace.create(Path(args.path).absolute(), force=args.w)
-        config.pluginmanager.hook.canary_initfinish(workspace=ws)
+        if args.post_actions:
+            config.pluginmanager.hook.canary_initfinish(workspace=ws)
         return 0


### PR DESCRIPTION
Many groups may have default search-paths, selections or other configurations that could be set up automatically for a streamlined developer experience. This PR implements a plugin hook for modifying the workspace upon initialization.