### PR TITLE
Updating hpc_connect API for futures interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
+    # be sure to remove futures branch
     "hpc-connect @ git+https://github.com/sandialabs/hpc-connect@futures",
     "pluggy>=1.5",
     "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
-    "hpc-connect @ git+https://github.com/sandialabs/hpc-connect",
+    "hpc-connect @ git+https://github.com/sandialabs/hpc-connect@futures",
     "pluggy>=1.5",
     "psutil",
     "pyyaml",

--- a/src/_canary/conductor.py
+++ b/src/_canary/conductor.py
@@ -4,6 +4,7 @@
 
 import io
 import threading
+import time
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -13,6 +14,7 @@ from .queue import ResourceQueue
 from .resource_pool import make_resource_pool
 from .resource_pool.rpool import Outcome
 from .util import logging
+from .util.multiprocessing import SimpleQueue
 
 if TYPE_CHECKING:
     from .resource_pool import ResourcePool
@@ -91,9 +93,10 @@ class CanaryConductor:
 class TestCaseExecutor:
     """Class for running ``AbstractTestCase``."""
 
-    def __call__(self, case: "TestCase", *args: str, **kwargs: Any) -> None:
+    def __call__(self, case: "TestCase", queue: SimpleQueue, **kwargs: Any) -> None:
         try:
             config.pluginmanager.hook.canary_runteststart(case=case)
+            queue.put(("STARTED", time.time()))
             config.pluginmanager.hook.canary_runtest(case=case)
         finally:
             config.pluginmanager.hook.canary_runtest_finish(case=case)

--- a/src/_canary/conductor.py
+++ b/src/_canary/conductor.py
@@ -104,6 +104,9 @@ class TestCaseExecutor:
 
     def __call__(self, case: "TestCase", queue: SimpleQueue, **kwargs: Any) -> None:
         try:
+            now = time.time()
+            queue.put(("SUBMITTED", now))
+            case.timekeeper.submitted = now
             config.pluginmanager.hook.canary_runteststart(case=case)
             queue.put(("STARTED", time.time()))
             config.pluginmanager.hook.canary_runtest(case=case)

--- a/src/_canary/database.py
+++ b/src/_canary/database.py
@@ -124,6 +124,7 @@ class WorkspaceDatabase:
             status_status TEXT,
             status_reason TEXT,
             status_code INTEGER,
+            submitted_on TEXT,
             started_on TEXT,
             finished_on TEXT,
             duration TEXT,
@@ -334,6 +335,7 @@ class WorkspaceDatabase:
                     case.status.status,
                     case.status.reason or "",
                     case.status.code,
+                    case.timekeeper.submitted_on,
                     case.timekeeper.started_on,
                     case.timekeeper.finished_on,
                     case.timekeeper.duration,
@@ -356,13 +358,14 @@ class WorkspaceDatabase:
                 status_status,
                 status_reason,
                 status_code,
+                submitted_on,
                 started_on,
                 finished_on,
                 duration,
                 workspace,
                 measurements
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 rows,
             )
@@ -436,13 +439,14 @@ class WorkspaceDatabase:
         )
         d["timekeeper"] = Timekeeper.from_dict(
             {
-                "started_on": row[11],
-                "finished_on": row[12],
-                "duration": float(row[13]),
+                "submitted_on": row[11],
+                "started_on": row[12],
+                "finished_on": row[13],
+                "duration": float(row[14]),
             }
         )
-        d["workspace"] = row[14]
-        d["measurements"] = Measurements.from_dict(json.loads(row[15]))
+        d["workspace"] = row[15]
+        d["measurements"] = Measurements.from_dict(json.loads(row[16]))
         return d
 
     def put_selection(

--- a/src/_canary/plugins/builtin/email.py
+++ b/src/_canary/plugins/builtin/email.py
@@ -62,10 +62,10 @@ def generate_html_report(session: "Session") -> str:
     file.write("<body>\n<h1>Canary test summary</h1>\n<table>\n")
     file.write("<tr><th>Test</th><th>Duration</th><th>Status</th></tr>\n")
     for group, cases in totals.items():
-        for case in sorted(cases, key=lambda c: c.timekeeper.duration):
+        for case in sorted(cases, key=lambda c: c.timekeeper.duration()):
             file.write(
                 f"<tr><td>{case.display_name()}</td>"
-                f"<td>{case.timekeeper.duration:.2f}</td>"
+                f"<td>{case.timekeeper.duration():.2f}</td>"
                 f"<td>{case.status.display_name(style='html')}</td></tr>\n"
             )
     file.write("</table>\n</body>\n</html>")

--- a/src/_canary/plugins/builtin/html.py
+++ b/src/_canary/plugins/builtin/html.py
@@ -73,7 +73,7 @@ class HTMLReporter(CanaryReporter):
         fh.write(f"<tr><td><b>Status:</b> {case.status.status}</td></tr>\n")
         fh.write(f"<tr><td><b>Exit code:</b> {case.status.code}</td></tr>\n")
         fh.write(f"<tr><td><b>ID:</b> {case.id}</td></tr>\n")
-        fh.write(f"<tr><td><b>Duration:</b> {case.timekeeper.duration}</td></tr>\n")
+        fh.write(f"<tr><td><b>Duration:</b> {case.timekeeper.duration()}</td></tr>\n")
         fh.write("</table>\n")
         fh.write("<h2>Test output</h2>\n<pre>\n")
         fh.write(case.read_output())
@@ -129,14 +129,14 @@ class HTMLReporter(CanaryReporter):
         fh.write('<table class="sortable">\n')
         fh.write("<thead><tr><th>Test</th><th>Duration</th><th>Status</th></tr></thead>\n")
         fh.write("<tbody>")
-        for case in sorted(cases, key=lambda c: c.timekeeper.duration):
+        for case in sorted(cases, key=lambda c: c.timekeeper.duration()):
             file = os.path.join(self.cases_dir, f"{case.id}.html")
             if not os.path.exists(file):
                 raise ValueError(f"{file}: html file not found")
             link = f'<a href="file://{file}">{case.display_name()}</a>'
             html_name = case.status.display_name(style="html")
             fh.write(
-                f"<tr><td>{link}</td><td>{case.timekeeper.duration:.2f}</td><td>{html_name}</td></tr>\n"
+                f"<tr><td>{link}</td><td>{case.timekeeper.duration():.2f}</td><td>{html_name}</td></tr>\n"
             )
         fh.write("</tbody>")
         fh.write("</table>\n</body>\n</html>")
@@ -147,13 +147,13 @@ class HTMLReporter(CanaryReporter):
         fh.write("<body>\n<h1>Test Results</h1>\n<table>\n")
         fh.write("<tr><th>Test</th><th>Duration</th><th>Status</th></tr>\n")
         for group, cases in totals.items():
-            for case in sorted(cases, key=lambda c: c.timekeeper.duration):
+            for case in sorted(cases, key=lambda c: c.timekeeper.duration()):
                 file = os.path.join(self.cases_dir, f"{case.id}.html")
                 if not os.path.exists(file):
                     raise ValueError(f"{file}: html file not found")
                 link = f'<a href="file://{file}">{case.display_name()}</a>'
                 html_name = case.status.display_name(style="html")
                 fh.write(
-                    f"<tr><td>{link}</td><td>{case.timekeeper.duration:.2f}</td><td>{html_name}</td></tr>\n"
+                    f"<tr><td>{link}</td><td>{case.timekeeper.duration():.2f}</td><td>{html_name}</td></tr>\n"
                 )
         fh.write("</table>\n</body>\n</html>")

--- a/src/_canary/plugins/builtin/junit.py
+++ b/src/_canary/plugins/builtin/junit.py
@@ -123,7 +123,7 @@ class JunitDocument(xdom.Document):
         testcase = self.create_element("testcase")
         testcase.setAttribute("name", case.display_name())
         testcase.setAttribute("classname", get_classname(case))
-        testcase.setAttribute("time", str(case.timekeeper.duration))
+        testcase.setAttribute("time", str(case.timekeeper.duration()))
         testcase.setAttribute("file", getattr(case, "relpath", str(case.spec.file_path)))
         if case.status.category == "FAIL":
             failure = self.create_element("failure")
@@ -160,18 +160,18 @@ def gather_statistics(cases: list["TestCase"]) -> SimpleNamespace:
         elif case.status.state in ("PENDING", "READY", "RUNNING"):
             stats.num_error += 1
         if case.status.state == "COMPLETE":
-            t = case.timekeeper.started_on
+            t = case.timekeeper.started
             if started_on is None:
-                if t != "NA":
-                    started_on = datetime.fromisoformat(t)
-            elif t != "NA" and datetime.fromisoformat(t) < started_on:
-                started_on = datetime.fromisoformat(t)
-            t = case.timekeeper.finished_on
+                if t > 0:
+                    started_on = datetime.fromtimestamp(t)
+            elif t > 0 and datetime.fromtimestamp(t) < started_on:
+                started_on = datetime.fromtimestamp(t)
+            t = case.timekeeper.finished
             if finished_on is None:
-                if t != "NA":
-                    finished_on = datetime.fromisoformat(t)
-            elif t != "NA" and datetime.fromisoformat(t) > finished_on:
-                finished_on = datetime.fromisoformat(t)
+                if t > 0:
+                    finished_on = datetime.fromtimestamp(t)
+            elif t > 0 and datetime.fromtimestamp(t) > finished_on:
+                finished_on = datetime.fromtimestamp(t)
     stats.started_on = started_on
     stats.finished_on = finished_on
     if started_on is not None and finished_on is not None:

--- a/src/_canary/plugins/builtin/markdown.py
+++ b/src/_canary/plugins/builtin/markdown.py
@@ -69,7 +69,7 @@ class MarkdownReporter(CanaryReporter):
             "**Exit code**": str(case.status.code),
             "**ID**": str(case.id),
             "**Location**": str(case.workspace.dir),
-            "**Duration**": f"{case.timekeeper.duration:.4f}",
+            "**Duration**": f"{case.timekeeper.duration():.4f}",
         }
         fh.write("|||\n|---|---|\n")
         for key, val in info.items():
@@ -114,7 +114,7 @@ class MarkdownReporter(CanaryReporter):
             if not os.path.exists(file):
                 raise ValueError(f"{file}: markdown file not found")
             link = f"[{case.display_name()}](./{os.path.basename(file)})"
-            duration = f"{case.timekeeper.duration:.2f}"
+            duration = f"{case.timekeeper.duration():.2f}"
             status = case.status.status
             fh.write(f"| {link} | {case.id} | {duration} | {status} |\n")
 
@@ -123,12 +123,12 @@ class MarkdownReporter(CanaryReporter):
         fh.write("| Test | Duration | Status |\n")
         fh.write("| --- | --- | --- |\n")
         for group, cases in totals.items():
-            for case in sorted(cases, key=lambda c: c.timekeeper.duration):
+            for case in sorted(cases, key=lambda c: c.timekeeper.duration()):
                 file = os.path.join(self.md_dir, f"{case.id}.md")
                 if not os.path.exists(file):
                     raise ValueError(f"{file}: markdown file not found")
                 link = f"[{case.display_name()}](./{os.path.basename(file)})"
-                duration = f"{case.timekeeper.duration:.2f}"
+                duration = f"{case.timekeeper.duration():.2f}"
                 status = case.status.status
                 fh.write(f"| {link} | {duration} | {status} |\n")
         fh.write("\n")

--- a/src/_canary/plugins/subcommands/status.py
+++ b/src/_canary/plugins/subcommands/status.py
@@ -96,9 +96,9 @@ class Status(CanarySubcommand):
         console = Console()
         if table.row_count > shutil.get_terminal_size().lines:
             with console.pager():
-                console.print(table, markup=True)
+                console.print(table)
         else:
-            console.print(table, markup=True)
+            console.print(table)
         if args.durations:
             console.print(format_durations(results, args.durations))
         return 0
@@ -146,10 +146,11 @@ class Status(CanarySubcommand):
                 row.append(str(entry["status"].code))
                 row.append(str(entry["timekeeper"].duration))
                 row.append(str(entry["status"].display_name(style="rich")))
+                print(row[-1])
                 row.append(str(entry["status"].reason))
                 table.add_row(*row)
         console = Console()
-        console.print(table, markup=True)
+        console.print(table)
 
 
 def sortkey(row: dict) -> tuple:

--- a/src/_canary/plugins/subcommands/status.py
+++ b/src/_canary/plugins/subcommands/status.py
@@ -8,6 +8,7 @@ import shutil
 from typing import TYPE_CHECKING
 from typing import Any
 
+from rich import box
 from rich.console import Console
 from rich.table import Table
 
@@ -108,7 +109,7 @@ class Status(CanarySubcommand):
         rows = filter_by_status(rows, args.report_chars)
         cols = args.format_cols.split(",")
 
-        table = Table(expand=True)
+        table = Table(expand=True, box=box.SQUARE)
         for col in cols:
             table.add_column(col)
 
@@ -133,7 +134,7 @@ class Status(CanarySubcommand):
 
     def print_spec_status_history(self, ids: list[str]) -> None:
         workspace = Workspace.load()
-        table = Table(expand=False)
+        table = Table(expand=False, box=box.SQUARE)
         for col in ["Name", "ID", "Session", "Exit Code", "Duration", "Status", "Details"]:
             table.add_column(col)
         for id in ids:

--- a/src/_canary/plugins/subcommands/status.py
+++ b/src/_canary/plugins/subcommands/status.py
@@ -144,9 +144,8 @@ class Status(CanarySubcommand):
                 row.append(entry["id"][:7])
                 row.append(entry["session"])
                 row.append(str(entry["status"].code))
-                row.append(str(entry["timekeeper"].duration))
+                row.append(str(entry["timekeeper"].duration()))
                 row.append(str(entry["status"].display_name(style="rich")))
-                print(row[-1])
                 row.append(str(entry["status"].reason))
                 table.add_row(*row)
         console = Console()
@@ -159,7 +158,7 @@ def sortkey(row: dict) -> tuple:
         c = 0
     if row["status"].category == "FAIL":
         c = 2
-    return (c, row["status"].status, row["timekeeper"].duration)
+    return (c, row["status"].status, row["timekeeper"].duration())
 
 
 def get_attribute(row: dict[str, Any], attr: str) -> str:
@@ -174,7 +173,7 @@ def get_attribute(row: dict[str, Any], attr: str) -> str:
     elif attr == "returncode":
         return str(row["status"].code)
     elif attr == "duration":
-        return dformat(row["timekeeper"].duration)
+        return dformat(row["timekeeper"].duration())
     elif attr == "status_name":
         return row["status"].display_name(style="rich")
     elif attr == "status_reason":
@@ -252,7 +251,7 @@ def filter_by_status(rows: list[dict], chars: str | None) -> list[dict]:
 
 
 def format_durations(results: dict[str, Any], N: int) -> str:
-    rows = sorted(results.values(), key=lambda x: x["timekeeper"].duration)
+    rows = sorted(results.values(), key=lambda x: x["timekeeper"].duration())
     ix = list(range(len(rows)))
     if N > 0:
         ix = ix[-N:]
@@ -260,7 +259,7 @@ def format_durations(results: dict[str, Any], N: int) -> str:
     fp = io.StringIO()
     fp.write("%(t)s%(t)s Slowest %(N)d durations %(t)s%(t)s\n" % kwds)
     for i in ix:
-        duration = rows[i]["timekeeper"].duration
+        duration = rows[i]["timekeeper"].duration()
         if duration < 0:
             continue
         name = rows[i]["spec_name"]

--- a/src/_canary/queue_executor.py
+++ b/src/_canary/queue_executor.py
@@ -15,6 +15,7 @@ from typing import Any
 from typing import Callable
 from typing import Literal
 
+from rich import box
 from rich import print as rprint
 from rich.console import Console
 from rich.console import Group
@@ -521,7 +522,7 @@ class ResourceQueueExecutor:
         footer = Table(expand=True, show_header=False, box=None)
         footer.add_column("stats")
         footer.add_row(text)
-        table = Table(expand=False)
+        table = Table(expand=False, box=box.SQUARE)
         fmt = config.getoption("live_name_fmt")
         if final:
             table.add_column("Job")
@@ -551,7 +552,7 @@ class ResourceQueueExecutor:
                 )
             return Group(table, footer)
 
-        table = Table(expand=False)
+        table = Table(expand=False, box=box.SQUARE)
         table.add_column("Job")
         table.add_column("ID")
         table.add_column("Status")

--- a/src/_canary/queue_executor.py
+++ b/src/_canary/queue_executor.py
@@ -305,8 +305,10 @@ class ResourceQueueExecutor:
         for pid, slot in list(self.inflight.items()):
             if not slot.proc.is_alive():
                 continue
+            if slot.start_time < 0:
+                continue
             total_timeout = slot.job.timeout * self.timeout_multiplier
-            if now - slot.submit_time > total_timeout:
+            if now - slot.start_time > total_timeout:
                 timed_out.append((pid, slot))
         for pid, slot in timed_out:
             _ = self.running.pop(pid, None) or self.submitted.pop(pid)

--- a/src/_canary/resource_pool/rpool.py
+++ b/src/_canary/resource_pool/rpool.py
@@ -13,7 +13,6 @@ import yaml
 
 from ..util import cpu_count
 from ..util import logging
-from ..util.rich import colorize
 from ..util.string import pluralize
 from .schemas import resource_pool_schema
 
@@ -232,12 +231,8 @@ class ResourcePool:
             reason: str
             levelno: int = logging.get_level()
             if levelno <= logging.DEBUG:
-                fmt = lambda t, n, m: "[bold]%s[/] (requested %d, available %d)" % (
-                    colorize(t),
-                    n,
-                    m,
-                )
-                types = ", ".join(fmt(k, *wanting[k]) for k in sorted(wanting))
+                t = "[bold]%s[/] (requested %d, available %d)"
+                types = ", ".join(t % (k, *wanting[k]) for k in sorted(wanting))
                 reason = f"insufficient slots of {types}"
             else:
                 types = ", ".join("[bold]%s[/]" % t for t in wanting)

--- a/src/_canary/rules.py
+++ b/src/_canary/rules.py
@@ -391,7 +391,7 @@ class RerunRule(RuntimeRule):
         elif self.strategy == "all":
             return RuleOutcome(ok=True)
         elif self.strategy == "changed":
-            t = case.timekeeper.start_time()
+            t = case.timekeeper.started
             if t < 0 or case.spec.file.stat().st_mtime > t:
                 return RuleOutcome(ok=True)
             return RuleOutcome(ok=False, reason="case spec has not changed since last run")

--- a/src/_canary/runtest.py
+++ b/src/_canary/runtest.py
@@ -202,7 +202,7 @@ def print_footer(runner: "Runner", title: str) -> None:
 
 
 def print_durations(cases: list["TestCase"], N: int) -> None:
-    cases.sort(key=lambda x: x.timekeeper.duration)
+    cases.sort(key=lambda x: x.timekeeper.duration())
     ix = list(range(len(cases)))
     if N > 0:
         ix = ix[-N:]
@@ -210,7 +210,7 @@ def print_durations(cases: list["TestCase"], N: int) -> None:
     fp = io.StringIO()
     fp.write("%(t)s%(t)s Slowest %(N)d durations %(t)s%(t)s\n" % kwds)
     for i in ix:
-        duration = cases[i].timekeeper.duration
+        duration = cases[i].timekeeper.duration()
         if duration < 0:
             continue
         name = cases[i].display_name(style="rich")

--- a/src/_canary/testcase.py
+++ b/src/_canary/testcase.py
@@ -362,6 +362,7 @@ class TestCase:
                 code=status.code,
             )
         if timekeeper := data.get("timekeeper"):
+            self.timekeeper.submitted_on = timekeeper.submitted_on
             self.timekeeper.started_on = timekeeper.started_on
             self.timekeeper.finished_on = timekeeper.finished_on
             self.timekeeper.duration = timekeeper.duration
@@ -434,6 +435,7 @@ class TestCase:
             code=status["code"],
         )
         tk = data["timekeeper"]
+        self.timekeeper.submitted_on = tk["submitted_on"]
         self.timekeeper.started_on = tk["started_on"]
         self.timekeeper.finished_on = tk["finished_on"]
         self.timekeeper.duration = tk["duration"]

--- a/src/_canary/testinst.py
+++ b/src/_canary/testinst.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import dataclasses
-import datetime
 import io
 import os
 from pathlib import Path
@@ -135,12 +134,8 @@ def from_testcase(case: "TestCase") -> TestInstance:
     sources: dict[str, list[tuple[str, str | None]]] = {}
     for asset in case.spec.assets:
         sources.setdefault(asset.action, []).append((str(asset.src), asset.dst))
-    start = -1.0
-    if case.timekeeper.started_on != "NA":
-        start = datetime.datetime.fromisoformat(case.timekeeper.started_on).timestamp()
-    stop = -1.0
-    if case.timekeeper.finished_on != "NA":
-        stop = datetime.datetime.fromisoformat(case.timekeeper.finished_on).timestamp()
+    start = case.timekeeper.started
+    stop = case.timekeeper.finished
     instance = cls(
         file_root=str(case.spec.file_root),
         file_path=str(case.spec.file_path),
@@ -198,12 +193,8 @@ def from_lock(lock: dict[str, Any], lookup: dict[str, TestInstance]) -> TestInst
     resources = lock["resources"]
     timekeeper = lock["timekeeper"]
 
-    start = -1.0
-    if timekeeper["started_on"] != "NA":
-        start = datetime.datetime.fromisoformat(timekeeper["started_on"]).timestamp()
-    stop = -1.0
-    if timekeeper["finished_on"] != "NA":
-        stop = datetime.datetime.fromisoformat(timekeeper["finished_on"]).timestamp()
+    start = timekeeper["started"]
+    stop = timekeeper["finished"]
     instance = cls(
         file_root=spec["file_root"],
         file_path=spec["file_path"],

--- a/src/_canary/timekeeper.py
+++ b/src/_canary/timekeeper.py
@@ -6,26 +6,23 @@ import dataclasses
 import datetime
 import time
 from contextlib import contextmanager
-from typing import Any
 from typing import Generator
 
 
 @dataclasses.dataclass
 class Timekeeper:
-    submitted_on: str = dataclasses.field(default="NA", init=False)
-    started_on: str = dataclasses.field(default="NA", init=False)
-    finished_on: str = dataclasses.field(default="NA", init=False)
-    duration: float = dataclasses.field(default=-1.0, init=False)
+    submitted: float = dataclasses.field(default=-1.0, init=False)
+    started: float = dataclasses.field(default=-1.0, init=False)
+    finished: float = dataclasses.field(default=-1.0, init=False)
     mark: float = dataclasses.field(default=-1.0, init=False, repr=False)
 
     def start(self) -> None:
-        self.mark = time.monotonic()
-        self.started_on = datetime.datetime.now().isoformat(timespec="microseconds")
+        self.started = time.time()
+        if self.submitted < 0:
+            self.submitted = self.started
 
     def stop(self) -> None:
-        self.duration = time.monotonic() - self.mark
-        self.finished_on = datetime.datetime.now().isoformat(timespec="microseconds")
-        self.mark = -1.0
+        self.finished = time.time()
 
     @contextmanager
     def timeit(self) -> Generator["Timekeeper", None, None]:
@@ -35,39 +32,48 @@ class Timekeeper:
         finally:
             self.stop()
 
+    def queued(self) -> float:
+        if self.started > 0:
+            if self.submitted < 0:
+                self.submitted = self.started
+            return self.started - self.submitted
+        return -1.0
+
+    def duration(self) -> float:
+        if self.finished > 0:
+            return self.finished - self.started
+        return -1.0
+
     def reset(self) -> None:
-        self.submitted_on = "NA"
-        self.started_on = "NA"
-        self.finished_on = "NA"
-        self.duration = -1.0
-        self.mark = -1.0
+        self.submitted = -1.0
+        self.started = -1.0
+        self.finished = -1.0
 
-    def update(
-        self, *, started_on: str, finished_on: str, duration: float, submitted_on: str = "NA"
-    ) -> None:
-        self.submitted_on = submitted_on
-        self.started_on = started_on
-        self.finished_on = finished_on
-        self.duration = duration
+    def update(self, *, started: float, finished: float, submitted: float = -1.0) -> None:
+        self.submitted = submitted
+        self.started = started
+        self.finished = finished
 
-    def asdict(self) -> dict[str, Any]:
-        return {
-            "submitted_on": self.submitted_on,
-            "started_on": self.started_on,
-            "finished_on": self.finished_on,
-            "duration": self.duration,
-        }
+    def isoformat(self, what: str) -> str:
+        t: float = getattr(self, what)
+        return datetime.datetime.fromtimestamp(t).isoformat(timespec="microseconds")
 
-    def start_time(self) -> float:
-        if self.started_on == "NA":
-            return -1.0
-        return datetime.datetime.fromisoformat(self.started_on).timestamp()
+    def asdict(self) -> dict[str, float]:
+        return {"submitted": self.submitted, "started": self.started, "finished": self.finished}
 
     @classmethod
-    def from_dict(cls, d: dict) -> "Timekeeper":
+    def from_dict(cls, d: dict[str, float]) -> "Timekeeper":
         self = cls()
-        self.submitted_on = d["submitted_on"]
-        self.started_on = d["started_on"]
-        self.finished_on = d["finished_on"]
-        self.duration = d["duration"]
+        self.submitted = float(d["submitted"])
+        self.started = float(d["started"])
+        self.finished = float(d["finished"])
+        return self
+
+    @classmethod
+    def from_isoformated_times(cls, d: dict[str, str]) -> "Timekeeper":
+        self = cls()
+        fn = datetime.datetime.fromisoformat
+        self.submitted = fn(d["submitted"]).timestamp()
+        self.started = fn(d["started"]).timestamp()
+        self.finished = fn(d["finished"]).timestamp()
         return self

--- a/src/_canary/timekeeper.py
+++ b/src/_canary/timekeeper.py
@@ -12,6 +12,7 @@ from typing import Generator
 
 @dataclasses.dataclass
 class Timekeeper:
+    submitted_on: str = dataclasses.field(default="NA", init=False)
     started_on: str = dataclasses.field(default="NA", init=False)
     finished_on: str = dataclasses.field(default="NA", init=False)
     duration: float = dataclasses.field(default=-1.0, init=False)
@@ -35,18 +36,23 @@ class Timekeeper:
             self.stop()
 
     def reset(self) -> None:
+        self.submitted_on = "NA"
         self.started_on = "NA"
         self.finished_on = "NA"
         self.duration = -1.0
         self.mark = -1.0
 
-    def update(self, *, started_on: str, finished_on: str, duration: float) -> None:
+    def update(
+        self, *, started_on: str, finished_on: str, duration: float, submitted_on: str = "NA"
+    ) -> None:
+        self.submitted_on = submitted_on
         self.started_on = started_on
         self.finished_on = finished_on
         self.duration = duration
 
     def asdict(self) -> dict[str, Any]:
         return {
+            "submitted_on": self.submitted_on,
             "started_on": self.started_on,
             "finished_on": self.finished_on,
             "duration": self.duration,
@@ -60,6 +66,7 @@ class Timekeeper:
     @classmethod
     def from_dict(cls, d: dict) -> "Timekeeper":
         self = cls()
+        self.submitted_on = d["submitted_on"]
         self.started_on = d["started_on"]
         self.finished_on = d["finished_on"]
         self.duration = d["duration"]

--- a/src/_canary/workspace.py
+++ b/src/_canary/workspace.py
@@ -296,17 +296,17 @@ class Workspace:
         self.add_session_results(session, update_view=update_view)
         return session
 
-    def add_session_results(self, results: Session, update_view: bool = True) -> None:
+    def add_session_results(self, session: Session, update_view: bool = True) -> None:
         """Update latest results, view, and refs with results from ``session``"""
-        self.db.put_results(results)
+        self.db.put_results(*session.cases)
 
         if update_view:
             view_entries: dict[Path, list[Path]] = {}
-            for case in results.cases:
+            for case in session.cases:
                 if case.workspace.session is not None:
                     prefix = self.sessions_dir / case.workspace.session
                 else:
-                    prefix = results.prefix
+                    prefix = session.prefix
                 relpath = case.workspace.dir.relative_to(prefix)
                 view_entries.setdefault(prefix, []).append(relpath)
             self.update_view(view_entries)
@@ -314,7 +314,7 @@ class Workspace:
         # Write meta data file refs/latest -> ../sessions/{session.root}
         file = self.refs_dir / "latest"
         file.unlink(missing_ok=True)
-        link = os.path.relpath(str(results.prefix), str(file.parent))
+        link = os.path.relpath(str(session.prefix), str(file.parent))
         file.write_text(str(link))
 
         # Write meta data file HEAD -> ./sessions/{session.root}

--- a/src/canary_cmake/cdash/xmlreporter.py
+++ b/src/canary_cmake/cdash/xmlreporter.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-import datetime
 import importlib.resources as ir
 import json
 import os
@@ -307,7 +306,7 @@ class CDashXMLReporter:
             results = doc.createElement("Results")
             add_named_measurement(results, "Exit Code", exit_code)
             add_named_measurement(results, "Exit Value", str(exit_value))
-            duration = max(0.0, case.timekeeper.duration)
+            duration = max(0.0, case.timekeeper.duration())
             add_named_measurement(results, "Command Line", command, type="cdata")
             add_named_measurement(results, "Execution Time", duration)
             if fail_reason is not None:
@@ -543,9 +542,9 @@ class TestData:
             self.status |= 2**2
 
     def add_test(self, case: "canary.TestCase") -> None:
-        if case.timekeeper.started_on != "NA" and case.timekeeper.finished_on != "NA":
-            start = datetime.datetime.fromisoformat(case.timekeeper.started_on).timestamp()
-            finish = datetime.datetime.fromisoformat(case.timekeeper.finished_on).timestamp()
+        if case.timekeeper.started > 0 and case.timekeeper.finished > 0:
+            start = case.timekeeper.started
+            finish = case.timekeeper.finished
             if start < self.start:
                 self.start = start
             if finish > self.stop:

--- a/src/canary_hpc/__init__.py
+++ b/src/canary_hpc/__init__.py
@@ -128,6 +128,6 @@ def series_runner(batch: "TestBatch", backend: hpc_connect.Backend) -> "HPCConne
     """Default implementation"""
     from .batchexec import HPCConnectSeriesRunner
 
-    if batch.spec.layout == "flat" and backend.supports_subscheduling:
+    if batch.spec.layout == "flat" and backend.supports_subscheduling():
         return HPCConnectSeriesRunner(backend)
     return None

--- a/src/canary_hpc/__init__.py
+++ b/src/canary_hpc/__init__.py
@@ -104,7 +104,7 @@ class CanaryHPCHooks:
     @staticmethod
     @canary.hookspec(firstresult=True)
     def canary_hpc_batch_runner(
-        batch: "TestBatch", backend: hpc_connect.HPCSubmissionManager
+        batch: "TestBatch", backend: hpc_connect.Backend
     ) -> "HPCConnectRunner":
         """Return a runner for this batch"""
         raise NotImplementedError
@@ -116,9 +116,7 @@ def canary_addhooks(pluginmanager: "canary.CanaryPluginManager"):
 
 
 @canary.hookimpl(trylast=True, specname="canary_hpc_batch_runner")
-def default_runner(
-    batch: "TestBatch", backend: hpc_connect.HPCSubmissionManager
-) -> "HPCConnectRunner | None":
+def default_runner(batch: "TestBatch", backend: hpc_connect.Backend) -> "HPCConnectRunner | None":
     """Default implementation"""
     from .batchexec import HPCConnectBatchRunner
 
@@ -126,9 +124,7 @@ def default_runner(
 
 
 @canary.hookimpl(specname="canary_hpc_batch_runner")
-def series_runner(
-    batch: "TestBatch", backend: hpc_connect.HPCSubmissionManager
-) -> "HPCConnectRunner | None":
+def series_runner(batch: "TestBatch", backend: hpc_connect.Backend) -> "HPCConnectRunner | None":
     """Default implementation"""
     from .batchexec import HPCConnectSeriesRunner
 

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -36,16 +36,12 @@ class HPCConnectRunner:
         
     def rc_environ(self, batch: "TestBatch") -> dict[str, str | None]:
         variables: dict[str, str | None] = dict(batch.variables)
-        variables.update(
-            {"CANARY_LEVEL": "1", "CANARY_DISABLE_KB": "1"}
-        )
+        variables.update({"CANARY_LEVEL": "1", "CANARY_DISABLE_KB": "1"})
         if canary.config.get("debug"):
             variables["CANARY_DEBUG"] = "on"
-
         f = batch.workspace.joinpath("config.json")
         with open(f, "w") as fh:
             canary.config.dump(fh)
-
         variables[canary.config.CONFIG_ENV_FILENAME] = str(f)
         return variables
 

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -74,16 +74,16 @@ class HPCConnectRunner:
 
     @contextmanager
     def handle_signals(
-        self, cancellables: list[Cancellable], batch: "TestBatch"
+        self, targets: list[Cancellable], batch: "TestBatch"
     ) -> Generator[None, None, None]:
         def cancel(signum, frame):
             logger.warning(f"Cancelling batch {batch} due to captured signal {signum!r}")
             try:
-                for c in cancellables:
+                for target in targets:
                     try:
-                        c.cancel()
+                        target.cancel()
                     except Exception as e:
-                        logger.debug(f"Failed to cancel {c}", exc_info=e)
+                        logger.debug(f"Failed to cancel {target}", exc_info=e)
             finally:
                 signal.signal(signum, signal.SIG_DFL)
                 os.kill(os.getpid(), signum)

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -33,7 +33,7 @@ class HPCConnectRunner:
 
     def execute(self, batch: "TestBatch") -> int | None:
         raise NotImplementedError
-        
+
     def rc_environ(self, batch: "TestBatch") -> dict[str, str | None]:
         variables: dict[str, str | None] = dict(batch.variables)
         variables.update({"CANARY_LEVEL": "1", "CANARY_DISABLE_KB": "1"})

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -105,7 +105,9 @@ class HPCConnectRunner:
 class HPCConnectBatchRunner(HPCConnectRunner):
     def execute(self, batch: "TestBatch", queue: SimpleQueue) -> int | None:
         def set_starttime(future):
-            queue.put(("STARTED", time.time()))
+            now = time.time()
+            batch.timekeeper.started = now
+            queue.put(("STARTED", now))
 
         def set_jobid(future):
             batch.jobid = future.jobid

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Generator
 from typing import Protocol
+from typing import Sequence
 
 import hpc_connect
 import hpc_connect.futures
@@ -26,7 +27,7 @@ logger = canary.get_logger(__name__)
 
 
 class Cancellable(Protocol):
-    def cancel(self) -> None: ...
+    def cancel(self) -> bool: ...
 
 
 class HPCConnectRunner:
@@ -76,7 +77,7 @@ class HPCConnectRunner:
 
     @contextmanager
     def handle_signals(
-        self, targets: list[Cancellable], batch: "TestBatch"
+        self, targets: Sequence[Cancellable], batch: "TestBatch"
     ) -> Generator[None, None, None]:
         def cancel(signum, frame):
             logger.warning(f"Cancelling batch {batch} due to captured signal {signum!r}")

--- a/src/canary_hpc/batchspec.py
+++ b/src/canary_hpc/batchspec.py
@@ -230,7 +230,7 @@ class TestBatch:
     ) -> None:
         self.status.set(state=state, category=category, status=status, reason=reason, code=code)
 
-    def run(self, backend: hpc_connect.HPCSubmissionManager) -> None:
+    def run(self, backend: hpc_connect.Backend) -> None:
         logger.debug(f"Running batch {self.id[:7]}")
         runner: "HPCConnectRunner" = canary.config.pluginmanager.hook.canary_hpc_batch_runner(
             backend=backend, batch=self

--- a/src/canary_hpc/batchspec.py
+++ b/src/canary_hpc/batchspec.py
@@ -288,9 +288,9 @@ class TestBatch:
                     propagate=False,
                 )
             if timekeeper := mydata.get("timekeeper"):
-                self.timekeeper.started_on = timekeeper.started_on
-                self.timekeeper.finished_on = timekeeper.finished_on
-                self.timekeeper.duration = timekeeper.duration
+                self.timekeeper.submitted = timekeeper.submitted
+                self.timekeeper.started = timekeeper.started
+                self.timekeeper.finished = timekeeper.finished
         for case in self.cases:
             if d := data.get(case.id):
                 case.setstate(d)
@@ -321,12 +321,12 @@ class TestBatch:
         """Return total, running, and time in queue"""
 
         def started(case):
-            s = case.timekeeper.started_on
-            return None if s == "NA" else datetime.datetime.fromisoformat(s)
+            t = case.timekeeper.started
+            return None if t < 0 else datetime.datetime.fromtimestamp(t)
 
         def finished(case):
-            f = case.timekeeper.finished_on
-            return None if f == "NA" else datetime.datetime.fromisoformat(f)
+            t = case.timekeeper.finished
+            return None if t < 0 else datetime.datetime.fromtimestamp(t)
 
         total_duration = self.timekeeper.duration
         duration: float | None = total_duration if total_duration > 0 else None

--- a/src/canary_hpc/batchspec.py
+++ b/src/canary_hpc/batchspec.py
@@ -7,6 +7,7 @@ import dataclasses
 import datetime
 import json
 import math
+import time
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -239,8 +240,12 @@ class TestBatch:
         rc: int | None = -1
         try:
             logger.debug(f"Submitting batch {self.id[:7]}")
-            with self.timekeeper.timeit():
+            queue.put(("SUBMITTED", time.time()))
+            self.timekeeper.submitted = time.time()
+            try:
                 rc = runner.execute(self, queue=queue)
+            finally:
+                self.timekeeper.finished = time.time()
         except Exception:
             rc = 1
         finally:

--- a/src/canary_hpc/conductor.py
+++ b/src/canary_hpc/conductor.py
@@ -37,7 +37,8 @@ logger = canary.get_logger(__name__)
 
 class CanaryHPCConductor:
     def __init__(self, *, backend: str) -> None:
-        self.backend: hpc_connect.Backend = hpc_connect.get_backend(backend)
+        config = hpc_connect.Config.from_defaults(overrides=dict(backend=backend))
+        self.backend: hpc_connect.Backend = hpc_connect.get_backend(config=config)
         # compute the total slots per resource type so that we can determine whether a test can be
         # run by this backend.
         self._slots_per_resource_type: Counter[str] | None = None
@@ -281,6 +282,7 @@ class BatchExecutor:
         hpc.propagate = True
         hpc.setLevel(logging.NOTSET)
         batch.setup()
-        backend = hpc_connect.get_backend(kwargs["backend"])
+        config = hpc_connect.Config.from_defaults(overrides=dict(backend=kwargs["backend"]))
+        backend: hpc_connect.Backend = hpc_connect.get_backend(config=config)
         batch.run(backend=backend)
         logger.debug(f"Done running {batch}")

--- a/src/canary_hpc/conductor.py
+++ b/src/canary_hpc/conductor.py
@@ -20,6 +20,7 @@ from _canary.resource_pool.rpool import Outcome
 from _canary.runtest import Runner
 from _canary.testexec import ExecutionSpace
 from _canary.util import cpu_count
+from _canary.util.multiprocessing import SimpleQueue
 from _canary.util.rich import colorize
 from _canary.util.time import time_in_seconds
 
@@ -275,7 +276,7 @@ class KeyboardQuit(Exception):
 class BatchExecutor:
     """Class for running ``ResourceQueue``."""
 
-    def __call__(self, batch: TestBatch, **kwargs: Any) -> None:
+    def __call__(self, batch: TestBatch, queue: SimpleQueue, **kwargs: Any) -> None:
         # Ensure the config is loaded, since this may be called in a new subprocess
         hpc = logging.getLogger("hpc_connect")
         hpc.handlers.clear()
@@ -284,5 +285,5 @@ class BatchExecutor:
         batch.setup()
         config = hpc_connect.Config.from_defaults(overrides=dict(backend=kwargs["backend"]))
         backend: hpc_connect.Backend = hpc_connect.get_backend(config=config)
-        batch.run(backend=backend)
+        batch.run(backend=backend, queue=queue)
         logger.debug(f"Done running {batch}")

--- a/src/canary_hpc/executor.py
+++ b/src/canary_hpc/executor.py
@@ -20,7 +20,8 @@ logger = canary.get_logger(__name__)
 
 class CanaryHPCExecutor:
     def __init__(self, *, workspace: str, backend: str, case: str | None = None) -> None:
-        self.backend: hpc_connect.Backend = hpc_connect.get_backend(backend)
+        config = hpc_connect.Config.from_defaults(overrides=dict(backend=backend))
+        self.backend: hpc_connect.Backend = hpc_connect.get_backend(config=config)
         config = TestBatch.loadconfig(workspace)
         self.session: str = config["session"]
         self.batch: str = config["id"]

--- a/src/canary_hpc/tests/canary_hpc/basic.py
+++ b/src/canary_hpc/tests/canary_hpc/basic.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
         dirs = os.listdir("TestResults")
         expected = ["VIEW.TAG"] + [f"test_{i}" for i in range(12)]
         assert sorted(expected) == sorted(dirs)
-        files = glob_files_in_session("canary-inp.sh")
+        files = glob_files_in_session("*.sh")
         assert len(files) == 4
         files = glob_files_in_session("canary-out.txt")
         assert len(files) == 4
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         dirs = os.listdir("TestResults")
         expected = ["VIEW.TAG"] + [f"test_{i}" for i in range(12)]
         assert sorted(expected) == sorted(dirs)
-        files = glob_files_in_session("canary-inp.sh")
+        files = glob_files_in_session("*.sh")
         assert len(files) == 4
         found = 0
         for line in open(files[0]):
@@ -133,7 +133,7 @@ if __name__ == '__main__':
         dirs = os.listdir("TestResults")
         expected = ["VIEW.TAG"] + [f"test_{i}" for i in range(12)]
         assert sorted(expected) == sorted(dirs)
-        files = glob_files_in_session("canary-inp.sh")
+        files = glob_files_in_session("*.sh")
         assert len(files) == 4
         files = glob_files_in_session("canary-out.txt")
         assert len(files) == 4
@@ -166,7 +166,7 @@ if __name__ == '__main__':
         dirs = os.listdir("TestResults")
         expected = ["VIEW.TAG"] + [f"test_{i}" for i in range(12)]
         assert sorted(expected) == sorted(dirs)
-        files = glob_files_in_session("canary-inp.sh")
+        files = glob_files_in_session("*.sh")
         assert len(files) == 4
         found = 0
         for line in open(files[0]):

--- a/src/canary_hpc/tests/canary_hpc/bfilter.py
+++ b/src/canary_hpc/tests/canary_hpc/bfilter.py
@@ -30,7 +30,7 @@ def test_repo_bfilter(tmpdir):
             )
             workspace.run(specs)
             files = glob.glob(
-                "tests/.canary/cache/canary-hpc/batches/**/canary-inp.sh",
+                "tests/.canary/cache/canary-hpc/batches/**/canary.*.sh",
                 recursive=True,
             )
             assert len(files) == 2

--- a/tests/issues/90/issue_90.py
+++ b/tests/issues/90/issue_90.py
@@ -25,11 +25,9 @@ def write_testfile(file):
 import os
 import sys
 import canary
-
 canary.directives.name("a")
 canary.directives.name("b")
 canary.directives.name("c")
-
 canary.directives.depends_on("c", when="testname=b")
 canary.directives.depends_on("b", when="testname=a")
 


### PR DESCRIPTION
The [futures](https://github.com/sandialabs/hpc-connect/tree/futures) branch of hoc-connect refactors the backend submission to use a futures interface, rather than a polling interface.  This PR updates canary to use that interface.