### PR TITLE
Write case results from a single writer 

### DIFF
--- a/src/_canary/database.py
+++ b/src/_canary/database.py
@@ -378,9 +378,6 @@ class WorkspaceDatabase:
         """
 
         rows = [self.format_single_result(case) for case in cases]
-        self.put_raw_results(rows)
-
-    def put_raw_results(self, rows: list[tuple[Any, ...]]) -> None:
         sql = """
         INSERT OR REPLACE INTO results (
           spec_id, spec_name, spec_fullname, file_root, file_path, session, workspace,

--- a/src/_canary/main.py
+++ b/src/_canary/main.py
@@ -39,6 +39,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     :returns: An exit code.
     """
+    if "CANARY_LEVEL" not in os.environ:
+        os.environ["CANARY_LEVEL"] = "0"
     with CanaryMain(argv) as m:
         parser = make_argument_parser()
         parser.add_main_epilog(parser)

--- a/src/_canary/plugins/subcommands/run.py
+++ b/src/_canary/plugins/subcommands/run.py
@@ -383,7 +383,7 @@ class PathSpec(argparse.Action):
         setattr(namespace, "script_args", script_args)
         setattr(namespace, self.dest, values)
         # backward compat
-        if request["kind"] == "scanpaths":
+        if request.get("kind") == "scanpaths":
             setattr(namespace, "scanpaths", request["payload"])
 
     @staticmethod

--- a/src/_canary/plugins/subcommands/status.py
+++ b/src/_canary/plugins/subcommands/status.py
@@ -80,19 +80,16 @@ class Status(CanarySubcommand):
             choices=("duration", "name"),
             help="Sort cases by this field [default: %(default)s]",
         )
-        parser.add_argument("--history", action="store_true", help="Print status history for specs")
         parser.add_argument(
-            "specs", nargs=argparse.REMAINDER, help="Show status for these specific specs"
+            "specs", nargs=argparse.REMAINDER, help="Show status history for these specific specs"
         )
 
     def execute(self, args: "argparse.Namespace") -> int:
-        if args.history:
+        if args.specs:
             self.print_spec_status_history(args.specs)
             return 0
-        if args.specs:
-            args.report_chars = "A"
         workspace = Workspace.load()
-        results = workspace.db.get_results(ids=args.specs)
+        results = workspace.db.get_results()
         table = self.get_status_table(results, args)
         console = Console()
         if table.row_count > shutil.get_terminal_size().lines:

--- a/src/_canary/queue_executor.py
+++ b/src/_canary/queue_executor.py
@@ -31,6 +31,7 @@ from .queue import ResourceQueue
 from .util import cpu_count
 from .util import logging
 from .util import multiprocessing as mp
+from .util.misc import boolean
 from .util.returncode import compute_returncode
 
 logger = logging.get_logger(__name__)
@@ -128,7 +129,9 @@ class ResourceQueueExecutor:
             self.live_reporting = False
         if not sys.stdin.isatty():
             self.live_reporting = False
-        if os.getenv("CANARY_LEVEL") == "1":
+        if not boolean(os.getenv("CANARY_LIVE")):
+            self.live_reporting = False
+        elif int(os.getenv("CANARY_LEVEL", "0")) > 0:
             self.live_reporting = False
         elif os.getenv("CANARY_MAKE_DOCS"):
             self.live_reporting = False

--- a/src/_canary/util/multiprocessing.py
+++ b/src/_canary/util/multiprocessing.py
@@ -431,6 +431,11 @@ class FSQueue:
         files = sorted(self.root.glob("*.pkl"), key=lambda f: f.stat().st_mtime)
         self._cache = files
 
+    def empty(self) -> bool:
+        if not self._cache:
+            self._refill_cache()
+        return bool(self._cache)
+
     def get(self) -> Any:
         """
         Get the oldest item from the queue.

--- a/src/_canary/util/multiprocessing.py
+++ b/src/_canary/util/multiprocessing.py
@@ -14,6 +14,9 @@ import sys
 import time
 import traceback
 from multiprocessing.process import BaseProcess
+from pathlib import Path
+from queue import Empty
+from tempfile import NamedTemporaryFile
 from typing import Any
 from typing import Callable
 from typing import Sequence
@@ -392,3 +395,70 @@ def starmap(
 
 def parent_process() -> BaseProcess | None:
     return multiprocessing.parent_process()
+
+
+class FSQueue:
+    """
+    A file-system-backed queue with caching.
+
+    Items are pickled to disk, multiple processes can safely put items,
+    and a listener can consume them in FIFO order.
+    """
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._cache: list[Path] = []
+
+    def put(self, obj: Any) -> None:
+        """Serialize and atomically store an object in the queue."""
+        temp_file: Path | None = None
+        try:
+            with NamedTemporaryFile(dir=self.root, delete=False, suffix=".tmp", mode="wb") as tf:
+                temp_file = Path(tf.name)
+                pickle.dump(obj, tf)
+                tf.flush()
+                tf.fileno()  # ensure file is written to disk
+            final_file = self.root / f"{temp_file.stem}.pkl"
+            temp_file.replace(final_file)  # atomic rename
+        except Exception as e:
+            if temp_file and temp_file.exists():
+                temp_file.unlink(missing_ok=True)
+            raise RuntimeError(f"Failed to put item in FSQueue: {e}")
+
+    def _refill_cache(self) -> None:
+        """Populate the internal cache from disk, sorted by modification time."""
+        files = sorted(self.root.glob("*.pkl"), key=lambda f: f.stat().st_mtime)
+        self._cache = files
+
+    def get(self) -> Any:
+        """
+        Get the oldest item from the queue.
+
+        Raises:
+            Empty: if the queue is empty.
+        """
+        if not self._cache:
+            self._refill_cache()
+        if not self._cache:
+            raise Empty()
+        f = self._cache.pop(0)
+        try:
+            with f.open("rb") as fh:
+                obj = pickle.load(fh)  # nosec B301
+            f.unlink(missing_ok=True)
+            return obj
+        except Exception as e:
+            f.unlink(missing_ok=True)
+            raise RuntimeError(f"Failed to read item from FSQueue: {e}")
+
+    def drain(self) -> list[Any]:
+        """
+        Yield items from the queue until empty.
+        """
+        objs: list[Any] = []
+        while True:
+            try:
+                objs.append(self.get())
+            except Empty:
+                return objs

--- a/src/_canary/workspace.py
+++ b/src/_canary/workspace.py
@@ -6,8 +6,13 @@ import datetime
 import fnmatch
 import os
 import shutil
+import threading
+import time
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 
 import yaml
 
@@ -34,6 +39,9 @@ from .util.filesystem import write_directory_tag
 from .util.graph import static_order
 from .util.names import unique_random_name
 from .version import __static_version__
+
+if TYPE_CHECKING:
+    from .queue_executor import EventTypes
 
 logger = logging.get_logger(__name__)
 
@@ -103,6 +111,7 @@ class Workspace:
 
         # Temporary data
         self.tmp_dir: Path
+        self.spool_dir: Path
 
         # Text logs
         self.logs_dir: Path
@@ -112,6 +121,8 @@ class Workspace:
 
         self.dbfile: Path
         self.db: WorkspaceDatabase
+
+        self.canary_level: int
 
         raise RuntimeError("Use Workspace factory methods create and load")
 
@@ -125,9 +136,15 @@ class Workspace:
         self.sessions_dir = self.root / "sessions"
         self.cache_dir = self.root / "cache"
         self.tmp_dir = self.root / "tmp"
+        self.spool_dir = self.tmp_dir / "spool"
         self.logs_dir = self.root / "logs"
         self.head = self.root / "HEAD"
         self.dbfile = self.root / "workspace.sqlite3"
+        self.canary_level = 0
+        if var := os.getenv("CANARY_LEVEL_OVERRIDE"):
+            self.canary_level = int(var)
+        elif var := os.getenv("CANARY_LEVEL"):
+            self.canary_level = int(var)
 
     @staticmethod
     def remove(start: str | Path = Path.cwd()) -> Path | None:
@@ -205,6 +222,7 @@ class Workspace:
         self.sessions_dir.mkdir(parents=True)
         self.cache_dir.mkdir(parents=True)
         self.tmp_dir.mkdir(parents=True)
+        self.spool_dir.mkdir(parents=True)
         self.logs_dir.mkdir(parents=True)
         version = self.root / "VERSION"
         version.write_text(".".join(str(_) for _ in self.version_info))
@@ -298,15 +316,31 @@ class Workspace:
 
         s = Session(name=session_dir.name, prefix=session_dir, cases=ready)
         config.pluginmanager.hook.canary_sessionstart(session=s)
+
+        # We need to take great care to only write results into the database from the parent process
+        # On the parent process, create a results listener that looks for results in the spool.
+        # As test cases finish, the testcase_done_callback is called and the results put into the
+        # spool.  When the listener detects the results, it will write them to the database.  This
+        # way, the database is only receiving results from a single writer.  Otherwise, results can
+        # be written from many writers originating from many different processes (eg, a canary
+        # instance launched inside a HPC scheduler)
+        self.db.close()
+        listener: ResultListener | None = None
+        if self.canary_level == 0:
+            listener = ResultListener(self.db, spool_dir=self.spool_dir)
+            listener.start()
         s.run(workspace=self)
+        if listener is not None:
+            listener.stop_and_join()
+            processed = [f.stem for f in listener._processed]
+            not_saved = [case for case in s.cases if case.id not in processed]
+            self.db.put_results(*not_saved)
         config.pluginmanager.hook.canary_sessionfinish(session=s)
         self.add_session_results(s, update_view=update_view)
         return s
 
     def add_session_results(self, session: Session, update_view: bool = True) -> None:
         """Update latest results, view, and refs with results from ``session``"""
-        self.db.put_results(*session.cases)
-
         if update_view:
             view_entries: dict[Path, list[Path]] = {}
             for case in session.cases:
@@ -713,6 +747,114 @@ class Workspace:
             else:
                 found.append(None)
         return found
+
+    def testcase_done_callback(self, event: "EventTypes", *args: Any) -> None:
+        if event == "job_finished":
+            case: TestCase = cast(TestCase, args[0].job)
+            data = self.db.format_single_result(case)
+            temp_file = None
+            final_file = self.spool_dir / f"{case.id}.json"
+            try:
+                # Write to a temporary file in the same directory
+                with NamedTemporaryFile("w", dir=self.spool_dir, delete=False) as tf:
+                    temp_file = Path(tf.name)
+                    json.dump(list(data), tf)
+                    tf.flush()
+                    os.fsync(tf.fileno())
+                # Atomically move to the final filename
+                temp_file.replace(final_file)
+            except Exception as e:
+                raise RuntimeError(f"Failed to write result for {case.id}: {e}")
+            finally:
+                # Cleanup temp file if it still exists
+                if temp_file and temp_file.exists():
+                    temp_file.unlink(missing_ok=True)
+
+
+class ResultListener(threading.Thread):
+    """
+    Watches a spool directory for JSON test results and writes them to SQLite in batches.
+    """
+
+    def __init__(
+        self,
+        db: WorkspaceDatabase,
+        spool_dir: str | Path,
+        poll_interval: float = 0.5,
+        batch_size: int = 10,
+        max_wait: float = 5.0,
+    ):
+        super().__init__(daemon=True)
+        self.db = db
+        self.spool_dir = Path(spool_dir)
+        self.poll_interval = poll_interval
+        self.batch_size = batch_size
+        self.max_wait = max_wait
+
+        self._stop_event = threading.Event()
+        self._processed: set[Path] = set()  # Track processed files
+
+        self.spool_dir.mkdir(parents=True, exist_ok=True)
+
+    def run(self):
+        """Main thread loop."""
+        self.db.connect()
+        try:
+            last_flush = time.time()
+            while not self._stop_event.is_set():
+                files = self.collect_files()
+                if files or (time.time() - last_flush > self.max_wait):
+                    self.flush(files)
+                    last_flush = time.time()
+                time.sleep(self.poll_interval)
+            # Final flush at shutdown
+            files = self.collect_files()
+            self.flush(files)
+        finally:
+            self.db.close()
+
+    def stop_and_join(self):
+        """Stop listener and wait for thread to finish."""
+        self._stop_event.set()
+        self.join()
+
+    def collect_files(self):
+        """Collect new JSON result files from spool directory, excluding already processed."""
+        all_files = set(self.spool_dir.glob("*.json"))
+        new_files = [f for f in all_files if f not in self._processed]
+        return new_files
+
+    def flush(self, files: list[Path]):
+        """Read JSON files and write them to the database."""
+        if not files:
+            return
+
+        rows: list[tuple[Any, ...]] = []
+        files_to_remove: list[Path] = []
+
+        for file in files[: self.batch_size]:  # respect batch_size
+            try:
+                with file.open("r") as f:
+                    data = json.load(f)
+                rows.append(tuple(data))
+                files_to_remove.append(file)
+            except json.JSONDecodeError:
+                # Partial write, try again later
+                continue
+            except Exception as e:
+                logger.warning("Skipping file %s due to error: %s", file, e)
+                files_to_remove.append(file)  # optional: move to failed dir instead
+
+        if rows:
+            self.db.put_raw_results(rows)
+
+        # Remove successfully processed files
+        for f in files_to_remove:
+            try:
+                f.unlink(missing_ok=True)
+                self._processed.add(f)
+            except Exception as e:
+                logger.warning("Could not remove file %s: %s", f, e)
 
 
 class WorkspaceExistsError(Exception):

--- a/src/canary_hpc/batchexec.py
+++ b/src/canary_hpc/batchexec.py
@@ -39,7 +39,10 @@ class HPCConnectRunner:
 
     def rc_environ(self, batch: "TestBatch") -> dict[str, str | None]:
         variables: dict[str, str | None] = dict(batch.variables)
-        variables.update({"CANARY_LEVEL": "1", "CANARY_DISABLE_KB": "1"})
+        level = int(os.getenv("CANARY_LEVEL", "0"))
+        variables.update(
+            {"CANARY_LEVEL": str(level + 1), "CANARY_DISABLE_KB": "1", "CANARY_LIVE": "0"}
+        )
         if canary.config.get("debug"):
             variables["CANARY_DEBUG"] = "on"
         f = batch.workspace.joinpath("config.json")

--- a/src/canary_hpc/batchspec.py
+++ b/src/canary_hpc/batchspec.py
@@ -79,7 +79,7 @@ class TestBatch:
 
         self.jobid: str | None = None
         self.id = self.spec.id
-        self.variables = {"CANARY_BATCH_ID": str(self.spec.id), "CANARY_LEVEL": "1"}
+        self.variables = {"CANARY_BATCH_ID": str(self.spec.id)}
         self.exclusive = False
         self.measurements = Measurements()
         self.timekeeper = Timekeeper()


### PR DESCRIPTION
## Overview

Fix SQLite multi-writer corruption by introducing a single-writer result listener

## Problem

Canary supports hierarchical, asynchronous execution of jobs:

* A parent Canary process discovers and schedules jobs
* Jobs may be executed directly or via batch plugins (e.g. HPC schedulers)
* Batch plugins may invoke `canary run` recursively
* Jobs complete asynchronously across many processes and nodes

Historically, job results were written directly to the shared SQLite database when `canary run` completes, not as results become available.   This implicitly created a multi-writer SQLite workload across processes and nodes in batched runs - something SQLite does not support.   This worked at the batch level mostly by accident since concurrent batch writes evidently hasn't happened (we would see database lock and/or corruption exceptions otherwise).

A recent attempt to write results when individual jobs finish resulted in `sqlite3.OperationalError` exceptions as hundreds of jobs attempted to write to the database at once in batched runs. 

## Solution: Single-Writer Result Listener with Filesystem Queue

This PR introduces a single-writer architecture for database writes:

* Only the top-level (parent) Canary process writes to SQLite
* All jobs, regardless of where they run, write results to a shared filesystem queue
* A listener thread in the parent process drains the queue and writes results to the database in batches

### Execution Flow

```mermaid
sequenceDiagram
    participant C as Child Process
    participant Q as FSQueue (.canary/tmp/db)
    participant L as Listener (Parent)
    participant D as SQLite DB

    C->>Q: put(job)
    Note over Q: Atomic file write\n(shared filesystem)

    L->>Q: drain()
    Q-->>L: jobs[]

    L->>D: put_results(jobs)
```

## What Changed

1) Filesystem-backed queue (FSQueue)
 * Jobs serialize themselves to disk on completion
 * Writes are atomic (temp file + rename)
 * Queue is accessible across processes and nodes

2) ResultListener (parent process only)
 * Started before Session.run()
 * Periodically drains the FSQueue
 * Writes results to SQLite in batches

3) Default execution plugin only
 * Registers the job completion callback
 * Batch plugins remain unchanged
 
4) Workspace safety checks
 * Workspace verifies all case results are persisted before exit
 * Any missing results are written synchronously as a final safeguard

