### PR TITLE
Make SubprocessLauncher the default and add command attribute to spec

### DIFF
--- a/src/_canary/launcher.py
+++ b/src/_canary/launcher.py
@@ -22,10 +22,10 @@ import psutil
 
 from . import config
 from .error import TestTimedOut
+from .hookspec import hookimpl
 from .util import logging
 from .util.module import load as load_module
 from .util.shell import source_rcfile
-from .hookspec import hookimpl
 
 if TYPE_CHECKING:
     from .testcase import TestCase
@@ -69,6 +69,8 @@ class SubprocessLauncher(Launcher):
                 args.extend(a)
             if a := case.get_attribute("script_args"):
                 args.extend(a)
+            if not args:
+                raise RuntimeError(f"{case}: not command defined")
             case.add_measurement("command_line", shlex.join(args))
             stdout: TextIO = open(case.stdout, "a")
             stderr: StdErrorT = subprocess.STDOUT if case.stderr is None else open(case.stderr, "a")
@@ -332,7 +334,6 @@ class MeasuredProcess:
                 "ave": sum(vals) / len(vals),
             }
         return measurements
-
 
 
 @hookimpl(trylast=True, specname="canary_runtest_launcher")

--- a/src/_canary/launcher.py
+++ b/src/_canary/launcher.py
@@ -3,13 +3,10 @@
 # SPDX-License-Identifier: MIT
 """Defines launchers for individual test cases"""
 
-import importlib
 import os
-import runpy
 import shlex
 import signal
 import subprocess
-import sys
 import time
 from abc import ABC
 from abc import abstractmethod
@@ -28,6 +25,7 @@ from .error import TestTimedOut
 from .util import logging
 from .util.module import load as load_module
 from .util.shell import source_rcfile
+from .hookspec import hookimpl
 
 if TYPE_CHECKING:
     from .testcase import TestCase
@@ -41,21 +39,9 @@ class Launcher(ABC):
     def run(self, case: "TestCase") -> int: ...
 
 
-def timeout_multiplier() -> float:
-    if cli_timeouts := config.getoption("timeout"):
-        if t := cli_timeouts.get("multiplier"):
-            return float(t)
-    elif t := config.get("run:timeout:multiplier"):
-        return float(t)
-    return 1.0
-
-
 class SubprocessLauncher(Launcher):
-    def __init__(self, args: list[str]) -> None:
-        self._default_args = args
-
-    def default_args(self, case: "TestCase") -> list[str]:
-        return list(self._default_args)
+    def __init__(self, args: list[str] | None = None) -> None:
+        self.default_args: list[str] = list(args or [])
 
     @contextmanager
     def context(self, case: "TestCase") -> Generator[None, None, None]:
@@ -77,7 +63,8 @@ class SubprocessLauncher(Launcher):
     def run(self, case: "TestCase") -> int:
         logger.debug(f"Starting {case.display_name()} on pid {os.getpid()}")
         with self.context(case):
-            args: list[str] = self.default_args(case)
+            args: list[str] = list(case.spec.command)
+            args.extend(self.default_args)
             if a := config.getoption("script_args"):
                 args.extend(a)
             if a := case.get_attribute("script_args"):
@@ -95,7 +82,7 @@ class SubprocessLauncher(Launcher):
             try:
                 mp.start()
                 start = time.time()
-                deadline = start + case.timeout * timeout_multiplier()
+                deadline = start + case.total_timeout()
                 while True:
                     mp.sample_metrics()
                     rc = mp.poll()
@@ -133,94 +120,13 @@ class SubprocessLauncher(Launcher):
                             except Exception:
                                 pass  # nosec B110
 
-                        raise TestTimedOut(
-                            f"Test exceeded timeout of {timeout_multiplier() * case.timeout:.1f} s"
-                        )
+                        raise TestTimedOut(f"Test exceeded timeout of {case.total_timeout():.1f} s")
 
                     time.sleep(0.1)
             finally:
                 stdout.close()
                 if not isinstance(stderr, int):
                     stderr.close()
-
-
-class PythonFileLauncher(SubprocessLauncher):
-    def __init__(self):
-        pass
-
-    def default_args(self, case: "TestCase") -> list[str]:
-        return [sys.executable, case.file.name]
-
-
-class PythonRunpyLauncher(Launcher):
-    @contextmanager
-    def context(self, case: "TestCase") -> Generator[None, None, None]:
-        """Temporarily patch:
-        • canary.get_instance() to return `case`
-        • canary.spec (optional)
-        • sys.argv (optional)
-        """
-        from .testinst import from_testcase as test_instance_factory
-
-        canary = importlib.import_module("canary")
-        old_argv = sys.argv.copy()
-        old_env = os.environ.copy()
-        old_cwd = Path.cwd()
-        old_path = sys.path.copy()
-
-        def get_instance():
-            return test_instance_factory(case)
-
-        def get_testcase():
-            return case
-
-        try:
-            case.set_runtime_env(os.environ)
-            for module in case.spec.modules or []:
-                load_module(module)
-            for rcfile in case.spec.rcfiles or []:
-                source_rcfile(rcfile)
-            sys.path.insert(0, str(case.workspace.dir))
-            setattr(canary, "get_instance", get_instance)
-            setattr(canary, "get_testcase", get_testcase)
-            setattr(canary, "__testcase__", case)
-            sys.argv = [sys.executable, case.spec.file.name]
-            if a := config.getoption("script_args"):
-                sys.argv.extend(a)
-            if a := case.get_attribute("script_args"):
-                sys.argv.extend(a)
-            sys.stdout = open(case.stdout, "a")
-            if case.stderr is None:
-                sys.stderr = sys.stdout
-            else:
-                sys.stderr = open(case.stderr, "a")
-            for module in case.spec.modules or []:
-                load_module(module)
-            for rcfile in case.spec.rcfiles or []:
-                source_rcfile(rcfile)
-            os.chdir(case.workspace.dir)
-            yield
-        finally:
-            delattr(canary, "get_instance")
-            delattr(canary, "get_testcase")
-            delattr(canary, "__testcase__")
-            os.chdir(old_cwd)
-            sys.argv.clear()
-            sys.argv.extend(old_argv)
-            os.environ.clear()
-            os.environ.update(old_env)
-            sys.path.clear()
-            sys.path.extend(old_path)
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
-
-    def run(self, case: "TestCase") -> int:
-        logger.debug(f"Starting {case.display_name()} on pid {os.getpid()}")
-        case.add_measurement("command_line", shlex.join(sys.argv))
-        with self.context(case):
-            runpy.run_path(case.spec.file.name, run_name="__main__")
-        logger.debug(f"Finished {case.display_name()}")
-        return 0
 
 
 class MeasuredProcess:
@@ -426,3 +332,9 @@ class MeasuredProcess:
                 "ave": sum(vals) / len(vals),
             }
         return measurements
+
+
+
+@hookimpl(trylast=True, specname="canary_runtest_launcher")
+def default_testcase_launcher(case: "TestCase") -> Launcher:
+    return SubprocessLauncher()

--- a/src/_canary/pluginmanager.py
+++ b/src/_canary/pluginmanager.py
@@ -27,6 +27,7 @@ class CanaryPluginManager(pluggy.PluginManager):
         from . import collect
         from . import conductor
         from . import generate
+        from . import launcher
         from . import runtest
         from . import select
         from .plugins import builtin
@@ -45,6 +46,7 @@ class CanaryPluginManager(pluggy.PluginManager):
         self.register(generate, "builtin.generate")
         self.register(gpu_select, "builtin.gpu_select")
         self.register(filter, "builtin.filter")
+        self.register(launcher, "builtin.launcher")
         self.register(runtest, "builtin.runtest")
         self.register(rp_hooks, "builtin.resource_pool")
         self.register(select, "builtin.select")

--- a/src/_canary/plugins/builtin/pyt.py
+++ b/src/_canary/plugins/builtin/pyt.py
@@ -4,21 +4,16 @@
 import glob
 import io
 import os
-import shlex
-import subprocess
 import sys
 import warnings
-from contextlib import contextmanager
 from pathlib import Path
 from string import Template
 from types import ModuleType
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Generator
 from typing import Literal
 from typing import Sequence
-from typing import TextIO
 from typing import cast
 
 from ... import config
@@ -27,17 +22,13 @@ from ... import when as m_when
 from ...error import diff_exit_status
 from ...generator import AbstractTestGenerator
 from ...hookspec import hookimpl
-from ...launcher import Launcher
-from ...launcher import SubprocessLauncher
 from ...paramset import ParameterSet
-from ...testcase import TestCase
 from ...testspec import Artifact
+from ...testspec import Asset
 from ...testspec import Mask
 from ...third_party.monkeypatch import monkeypatch
 from ...util import graph
 from ...util import logging
-from ...util.module import load as load_module
-from ...util.shell import source_rcfile
 from ...util.string import pluralize
 from ...util.string import stringify
 from ...util.time import time_in_seconds
@@ -241,6 +232,7 @@ class PYTTestGenerator(AbstractTestGenerator):
                     dependencies=self.depends_on(
                         testname=name, parameters=parameters, on_options=on_options
                     ),
+                    command=[sys.executable, os.path.basename(self.path)],
                 )
                 enabled, reason = self.enable(
                     testname=name, on_options=on_options, parameters=parameters
@@ -292,11 +284,32 @@ class PYTTestGenerator(AbstractTestGenerator):
                     owners=self.owners,
                     artifacts=self.artifacts(testname=name, on_options=on_options),
                     exclusive=self.exclusive(testname=name, on_options=on_options),
-                    attributes={"multicase": True, "analyze": ns.value, "paramsets": psets},
+                    attributes={"multicase": True, "paramsets": psets},
                     dependencies=dependencies,
                 )
                 if test_mask is not None:
                     parent.mask = Mask.masked(test_mask)
+                command: list[str]
+                if flag := getattr(ns, "flag", None):
+                    command = [sys.executable, os.path.basename(self.path), flag]
+                elif script := getattr(ns, "script", None):
+                    f: Path
+                    if os.path.exists(script):
+                        f = Path(script).absolute()
+                    else:
+                        f = Path(os.path.join(self.root, os.path.dirname(self.path), script))
+                    if not f.exists():
+                        logger.warning(f"{self}: analyze script {f} not found")
+                    for asset in parent.assets:
+                        if asset.action in ("link", "copy") and f.name == asset.src.name:
+                            break
+                    else:
+                        asset = Asset(f, f.name, action="link")
+                        parent.assets.append(asset)
+                    command = [f.as_posix()]
+                else:
+                    command = [sys.executable, os.path.basename(self.path)]
+                parent.command = command
                 if any([_[1] is not None for _ in modules]):
                     mp = [_.strip() for _ in os.getenv("MODULEPATH", "").split(":") if _.split()]
                     for _, use in modules:
@@ -785,12 +798,7 @@ class PYTTestGenerator(AbstractTestGenerator):
                 "PYTTestGenerator.generate_composite_base_case: "
                 "'script' and 'flag' keyword arguments are mutually exclusive"
             )
-        arg: str | None = None
-        if script is not None:
-            arg = script
-        elif flag is not None:
-            arg = flag
-        ns = FilterNamespace(arg, when=when, requires=requires)
+        ns = FilterNamespace(None, when=when, requires=requires, flag=flag, script=script)
         self._generate_composite_base_case.append(ns)
 
     def m_name(self, arg: str) -> None:
@@ -1012,57 +1020,6 @@ class PYTTestGenerator(AbstractTestGenerator):
         self.m_baseline(src, dst, when=when, flag=flag)
 
 
-class PYTLauncher(Launcher):
-    @contextmanager
-    def context(self, case: "TestCase") -> Generator[None, None, None]:
-        old_env = os.environ.copy()
-        try:
-            case.set_runtime_env(os.environ)
-            for module in case.spec.modules or []:
-                load_module(module)
-            for rcfile in case.spec.rcfiles or []:
-                source_rcfile(rcfile)
-            yield
-        finally:
-            os.environ.clear()
-            os.environ.update(old_env)
-
-    def run(self, case: "TestCase") -> int:
-        logger.debug(f"Starting {case.display_name()} on pid {os.getpid()}")
-        with self.context(case):
-            args = [sys.executable, case.spec.file.name]
-            if a := config.getoption("script_args"):
-                args.extend(a)
-            if a := case.get_attribute("script_args"):
-                args.extend(a)
-            case.add_measurement("command_line", shlex.join(args))
-            stdout = open(case.stdout, "a")
-            stderr: TextIO | int
-            if case.stderr is None:
-                stderr = subprocess.STDOUT
-            else:
-                stderr = open(case.stderr, "a")
-            try:
-                cp = subprocess.run(
-                    args, cwd=case.workspace.dir, stdout=stdout, stderr=stderr, check=False
-                )
-            finally:
-                stdout.close()
-                if isinstance(stderr, io.TextIOWrapper):
-                    stderr.close()
-        logger.debug(f"Finished {case.display_name()}")
-        return cp.returncode
-
-
 @hookimpl
 def canary_collectstart(collector) -> None:
     collector.add_generator(PYTTestGenerator)
-
-
-@hookimpl
-def canary_runtest_launcher(case: TestCase) -> Launcher | None:
-    if case.spec.file.suffix in (".pyt", ".py"):
-        if script := case.get_attribute("alt_script"):
-            return SubprocessLauncher([f"./{script}"])
-        return PYTLauncher()
-    return None

--- a/src/_canary/testspec.py
+++ b/src/_canary/testspec.py
@@ -106,6 +106,7 @@ class BaseSpec(Generic[T]):
     environment: dict[str, str] = dataclasses.field(default_factory=dict)
     environment_modifications: list[dict[str, str]] = dataclasses.field(default_factory=list)
     meta_parameters: dict[str, Any] = dataclasses.field(default_factory=dict)
+    command: list[str] = dataclasses.field(default_factory=list)
     id: str = ""
 
     def __str__(self) -> str:
@@ -394,7 +395,6 @@ class UnresolvedSpec(BaseSpec["UnresolvedSpec"]):
         self.assets = self.assets or self._generate_assets(self.file_resources or {})
         self.baseline_actions = self._generate_baseline_actions(self.baseline or [])
         self.dep_patterns = self._generate_dependency_patterns(self.dependencies or [])
-        self._generate_analyze_action()
 
     def __hash__(self) -> int:
         return hash(self.id)
@@ -435,6 +435,7 @@ class UnresolvedSpec(BaseSpec["UnresolvedSpec"]):
             stdout=self.stdout,
             stderr=self.stderr,
             id=self.id,
+            command=self.command,
         )
 
     def is_resolved(self) -> bool:
@@ -473,27 +474,6 @@ class UnresolvedSpec(BaseSpec["UnresolvedSpec"]):
                 src, dst = item
                 actions.append({"type": "copy", "src": src, "dst": dst})
         return actions
-
-    def _generate_analyze_action(self) -> None:
-        if analyze := self.attributes.get("analyze"):
-            if analyze.startswith("-"):
-                self.attributes["script_args"] = [analyze]
-            else:
-                src: Path
-                if os.path.exists(analyze):
-                    src = Path(analyze).absolute()
-                else:
-                    src = self.file.parent / analyze
-                if not src.exists():
-                    logger.warning(f"{self}: analyze script {analyze} not found")
-                self.attributes["alt_script"] = src.name
-                # flag is a script to run during analysis, check if it is going to be copied/linked
-                for asset in self.assets:
-                    if asset.action in ("link", "copy") and src.name == asset.src.name:
-                        break
-                else:
-                    asset = Asset(src, src.name, action="link")
-                    self.assets.append(asset)
 
     def _generate_dependency_patterns(
         self, args: Sequence[str | DependencyPatterns]

--- a/src/_canary/third_party/programoutput/__init__.py
+++ b/src/_canary/third_party/programoutput/__init__.py
@@ -328,6 +328,12 @@ def _prompt_template_as_unicode(app):
     return tmpl
 
 
+def traverse(node, arg):
+    if hasattr(node, "findall"):
+        return node.findall(arg)
+    return node.traverse(arg)
+
+
 def run_programs(app, doctree):
     """
     Execute all programs represented by ``program_output`` nodes in
@@ -345,7 +351,7 @@ def run_programs(app, doctree):
 
     cache = app.env.programoutput_cache
     cache_d = os.path.join(app.env.srcdir, ".cache")
-    for node in doctree.traverse(program_output):
+    for node in traverse(doctree, program_output):
         command = Command.from_program_output_node(node)
         f = os.path.join(cache_d, command.id())
         try:

--- a/src/_canary/util/filesystem.py
+++ b/src/_canary/util/filesystem.py
@@ -18,6 +18,8 @@ import time
 from contextlib import contextmanager
 from typing import Any
 from typing import Generator
+from typing import Literal
+from typing import overload
 
 __all__ = [
     "ancestor",
@@ -66,6 +68,22 @@ def max_name_length() -> int:
 
 
 PathLike = pathlib.Path | str
+
+
+@overload
+def which(
+    *args: str,
+    path: str | list[str] | tuple[str, ...] | None = None,
+    required: Literal[True],
+) -> str: ...
+
+
+@overload
+def which(
+    *args: str,
+    path: str | list[str] | tuple[str, ...] | None = None,
+    required: Literal[False] = False,
+) -> str | None: ...
 
 
 def which(

--- a/src/canary/__init__.py
+++ b/src/canary/__init__.py
@@ -24,7 +24,6 @@ from _canary.generator import AbstractTestGenerator
 from _canary.hookspec import hookimpl
 from _canary.hookspec import hookspec
 from _canary.launcher import Launcher
-from _canary.launcher import PythonFileLauncher
 from _canary.launcher import SubprocessLauncher
 from _canary.main import console_main
 from _canary.pluginmanager import CanaryPluginManager

--- a/src/canary/__init__.py
+++ b/src/canary/__init__.py
@@ -38,6 +38,7 @@ from _canary.select import Selector
 from _canary.testcase import TestCase
 from _canary.testinst import TestInstance
 from _canary.testinst import TestMultiInstance
+from _canary.testspec import Artifact
 from _canary.testspec import Asset
 from _canary.testspec import DependencyPatterns
 from _canary.testspec import Mask
@@ -96,11 +97,11 @@ __all__ = [
     "TestCase",
     "Launcher",
     "logging",
-    "PythonFileLauncher",
     "SubprocessLauncher",
     "TestInstance",
     "TestMultiInstance",
     "DependencyPatterns",
+    "Artifact",
     "Asset",
     "ResolvedSpec",
     "UnresolvedSpec",

--- a/src/canary_cmake/__init__.py
+++ b/src/canary_cmake/__init__.py
@@ -14,7 +14,6 @@ from schema import Schema
 import canary
 
 from .cdash import CDashReporter
-from .ctest import CTestLauncher
 from .ctest import CTestTestGenerator
 from .ctest import finish_ctest
 from .ctest import read_resource_specs
@@ -39,13 +38,6 @@ def canary_collect_modifyitems(collector: canary.Collector) -> None:
             paths.sort(key=lambda p: (p.split(os.sep), p))
             for path in paths[1:]:
                 collector.remove_file(root, path)
-
-
-@canary.hookimpl
-def canary_runtest_launcher(case: canary.TestCase) -> canary.Launcher | None:
-    if case.spec.file.suffix == ".cmake":
-        return CTestLauncher()
-    return None
 
 
 @canary.hookimpl

--- a/src/canary_cmake/ctest.py
+++ b/src/canary_cmake/ctest.py
@@ -188,16 +188,18 @@ def create_draft_spec(
 
     attributes: dict[str, Any] = kwargs.setdefault("attributes", {})
 
-    kwargs["command"] = attributes["ctest_command"] = command
     attributes["will_fail"] = will_fail or False
 
     attributes["ctestfile"] = str(ctestfile)
     attributes["ctest_working_directory"] = working_directory
     attributes["binary_dir"] = os.path.dirname(str(ctestfile))
-    if working_directory is not None:
-        attributes["execution_directory"] = working_directory
-    else:
-        attributes["execution_directory"] = attributes["binary_dir"]
+
+    sh = canary.filesystem.which("sh", required=True)
+    exec_dir = attributes["binary_dir"] if working_directory is None else working_directory
+    exec_dir = os.path.abspath(exec_dir)
+    kwargs["command"] = [sh, "-c", f"cd {shlex.quote(exec_dir)} && exec {shlex.join(command)}"]
+    attributes["ctest_command"] = command
+    attributes["ctest_exec_dir"] = exec_dir
 
     if processors is not None:
         kwargs.setdefault("parameters", {})["cpus"] = processors
@@ -212,7 +214,7 @@ def create_draft_spec(
     if environment is not None:
         kwargs.setdefault("environment", {}).update(environment)
     if disabled:
-        kwargs["mask"] = f"Explicitly disabled in {file_root}/{file_path}"
+        kwargs["mask"] = canary.Mask.masked(f"Explicitly disabled in {file_root}/{file_path}")
 
     attributes.setdefault("resource_groups", [])
     if resource_groups is not None:
@@ -225,10 +227,12 @@ def create_draft_spec(
 
     if attached_files is not None:
         artifacts = kwargs.setdefault("artifacts", [])
-        artifacts.extend([{"file": f, "when": "always"} for f in attached_files])
+        artifacts.extend([canary.Artifact(pattern=f, when="always") for f in attached_files])
     if attached_files_on_fail is not None:
         artifacts = kwargs.setdefault("artifacts", [])
-        artifacts.extend([{"file": f, "when": "on_failure"} for f in attached_files_on_fail])
+        artifacts.extend(
+            [canary.Artifact(pattern=f, when="on_failure") for f in attached_files_on_fail]
+        )
     if run_serial is True:
         kwargs["exclusive"] = True
     if required_files:
@@ -307,21 +311,8 @@ def env_mods(mods: list[dict[str, str]]) -> list[dict[str, str]]:
 
 
 def setup_ctest(case: canary.TestCase):
-    sh = canary.filesystem.which("sh")
-    exec_dir = case.attributes["execution_directory"]
-    assert exec_dir is not None
-    args = case.attributes["ctest_command"]
-    assert args is not None
     variables = resource_groups_vars(case)
     case.add_variables(**variables)
-    with case.workspace.openfile("runtest.sh", "w") as fh:
-        fh.write(f"#!{sh}\n")
-        fh.write(f"cd {exec_dir}\n")
-        for name, value in variables.items():
-            fh.write(f"export {name}={value}\n")
-        fh.write(shlex.join(args))
-    case.spec.command = [case.workspace.joinpath("runtest.sh").as_posix()]
-    canary.filesystem.set_executable(case.workspace.joinpath("runtest.sh"))
 
 
 def resource_groups_vars(case: canary.TestCase) -> dict[str, str]:
@@ -456,7 +447,7 @@ def load(file: str) -> dict[str, Any]:
     tests: dict[str, Any] = {}
     logger.debug(f"Loading ctest tests from {file}")
 
-    ctest = canary.filesystem.which("ctest")
+    ctest = canary.filesystem.which("ctest", required=True)
     assert ctest is not None
 
     with canary.filesystem.working_dir(os.path.dirname(file)):

--- a/src/canary_cmake/ctest.py
+++ b/src/canary_cmake/ctest.py
@@ -10,7 +10,6 @@ import shlex
 import subprocess
 from pathlib import Path
 from typing import Any
-from typing import TextIO
 
 import schema
 
@@ -141,29 +140,6 @@ class CTestTestGenerator(canary.AbstractTestGenerator):
         return resolved
 
 
-class CTestLauncher(canary.Launcher):
-    def run(self, case: "canary.TestCase") -> int:
-        logger.debug(f"Starting {case.display_name()} on pid {os.getpid()}")
-        cwd = case.spec.attributes["execution_directory"]
-        args = case.spec.attributes["command"]
-        env: dict[str, str] = {k: v for k, v in case.variables.items() if v is not None}
-        case.add_measurement("command_line", shlex.join(args))
-        stdout = open(case.stdout, "a")
-        stderr: TextIO | int
-        if case.stderr is None:
-            stderr = subprocess.STDOUT
-        else:
-            stderr = open(case.stderr, "a")
-        try:
-            cp = subprocess.run(args, env=env, cwd=cwd, stdout=stdout, stderr=stderr, check=False)
-        finally:
-            stdout.close()
-            if isinstance(stderr, io.TextIOWrapper):
-                stderr.close()
-        logger.debug(f"Finished {case.display_name()}")
-        return cp.returncode
-
-
 def create_draft_spec(
     *,
     file_root: str,
@@ -212,7 +188,7 @@ def create_draft_spec(
 
     attributes: dict[str, Any] = kwargs.setdefault("attributes", {})
 
-    attributes["command"] = command
+    kwargs["command"] = attributes["ctest_command"] = command
     attributes["will_fail"] = will_fail or False
 
     attributes["ctestfile"] = str(ctestfile)
@@ -332,8 +308,10 @@ def env_mods(mods: list[dict[str, str]]) -> list[dict[str, str]]:
 
 def setup_ctest(case: canary.TestCase):
     sh = canary.filesystem.which("sh")
-    exec_dir = case.spec.attributes["execution_directory"]
-    args = case.spec.attributes["command"]
+    exec_dir = case.attributes["execution_directory"]
+    assert exec_dir is not None
+    args = case.attributes["ctest_command"]
+    assert args is not None
     variables = resource_groups_vars(case)
     case.add_variables(**variables)
     with case.workspace.openfile("runtest.sh", "w") as fh:
@@ -342,6 +320,7 @@ def setup_ctest(case: canary.TestCase):
         for name, value in variables.items():
             fh.write(f"export {name}={value}\n")
         fh.write(shlex.join(args))
+    case.spec.command = [case.workspace.joinpath("runtest.sh").as_posix()]
     canary.filesystem.set_executable(case.workspace.joinpath("runtest.sh"))
 
 

--- a/src/canary_cmake/tests/canary_cmake/ctest.py
+++ b/src/canary_cmake/tests/canary_cmake/ctest.py
@@ -62,14 +62,14 @@ set_tests_properties(test2 PROPERTIES  ENVIRONMENT "CTEST_NUM_RANKS=5;EGGS=SPAM"
         assert spec.parameters["gpus"] == 5
         assert "foo" in spec.keywords
         assert "baz" in spec.keywords
-        command = spec.attributes["command"]
+        command = spec.attributes["ctest_command"]
         command[0] = os.path.basename(command[0])
         assert command == ["script.sh", "some-exe"]
         assert spec.environment["CTEST_NUM_RANKS"] == "5"
         assert spec.environment["SPAM"] == "BAZ"
 
         spec = specs[1]
-        command = spec.attributes["command"]
+        command = spec.attributes["ctest_command"]
         command[0] = os.path.basename(command[0])
         assert command == ["mpiexec", "-n", "4", "some-exe"]
         assert spec.parameters["cpus"] == 4

--- a/src/canary_cmake/tests/canary_cmake/issues/86/issue_86.py
+++ b/src/canary_cmake/tests/canary_cmake/issues/86/issue_86.py
@@ -17,6 +17,6 @@ def test_issue_86():
     generator = ctg.CTestTestGenerator(file)
     specs = generator.lock()
     for spec in specs:
-        assert os.path.basename(spec.attributes["command"][0]) == "echo"
-        assert spec.attributes["command"][-1] == "yaml"
+        assert os.path.basename(spec.attributes["ctest_command"][0]) == "echo"
+        assert spec.attributes["ctest_command"][-1] == "yaml"
     force_remove(os.path.join(os.path.dirname(__file__), "Testing"))

--- a/src/canary_vvtest/__init__.py
+++ b/src/canary_vvtest/__init__.py
@@ -11,7 +11,6 @@ import typing
 
 import canary
 
-from .generator import VVTLauncher
 from .generator import VVTTestGenerator
 
 logger = canary.get_logger(__name__)
@@ -54,13 +53,6 @@ def canary_runteststart(case: "canary.TestCase") -> None:
     if case.spec.file_path.suffix == ".vvt":
         with canary.filesystem.working_dir(case.workspace.dir):
             write_vvtest_util(case)
-
-
-@canary.hookimpl
-def canary_runtest_launcher(case: canary.TestCase) -> canary.Launcher | None:
-    if case.spec.file.suffix == ".vvt":
-        return VVTLauncher()
-    return None
 
 
 @canary.hookimpl

--- a/src/canary_vvtest/generator.py
+++ b/src/canary_vvtest/generator.py
@@ -10,7 +10,6 @@ import json.decoder
 import os
 import re
 import shlex
-import subprocess
 import sys
 import tokenize
 from itertools import repeat
@@ -20,7 +19,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
 from typing import Generator
-from typing import TextIO
 
 import canary
 from _canary.enums import list_parameter_space
@@ -674,35 +672,6 @@ def to_seconds(arg: str | int | float, round: bool = False, negatives: bool = Fa
     if round:
         return int(seconds)
     return seconds
-
-
-class VVTLauncher(canary.Launcher):
-    def run(self, case: "canary.TestCase") -> int:
-        logger.debug(f"Starting {case.display_name()} on pid {os.getpid()}")
-        env = os.environ.copy()
-        case.set_runtime_env(env)
-        args = [sys.executable, case.spec.file.name]
-        if a := canary.config.getoption("script_args"):
-            args.extend(a)
-        if a := case.get_attribute("script_args"):
-            args.extend(a)
-        case.add_measurement("command_line", shlex.join(args))
-        stdout = open(case.stdout, "a")
-        stderr: TextIO | int
-        if case.stderr is None:
-            stderr = subprocess.STDOUT
-        else:
-            stderr = open(case.stderr, "a")
-        try:
-            cp = subprocess.run(
-                args, cwd=case.workspace.dir, env=env, stdout=stdout, stderr=stderr, check=False
-            )
-        finally:
-            stdout.close()
-            if isinstance(stderr, io.TextIOWrapper):
-                stderr.close()
-        logger.debug(f"Finished {case.display_name()}")
-        return cp.returncode
 
 
 class ParseError(Exception):


### PR DESCRIPTION
Most test cases don't need to define a launcher, they can use the SubprocessLauncher.  This PR command attribute to the spec that tests can define.  It works for the ctest, vvt, and pyt plugins - they all just define spec.command.  The ability to override the launcher is still here.