### PR TITLE
Convert MD5 usage to SHA256 for FIPS Compliance

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Ruff
         run: |
           ruff format --check --diff
-          ruff check --show-fixes --exclude=src/canary/__init__.py
+          ruff check --extend-selct S324 --show-fixes --exclude=src/canary/__init__.py
 
       - name: MyPy type checking
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Ruff
         run: |
           ruff format --check --diff
-          ruff check --extend-selct S324 --show-fixes --exclude=src/canary/__init__.py
+          ruff check --extend-select S324 --show-fixes --exclude=src/canary/__init__.py
 
       - name: MyPy type checking
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -272,7 +272,7 @@ lint::check:
   - python3 -m pip install $STD_PIP_ARGS ruff
   - ruff --version
   - git fetch origin "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:?}"
-  - ./bin/ci/ruff-check --ref="origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:?}" --output-format=junit --output-file=ruff.xml
+  - ./bin/ci/ruff-check --ref="origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:?}" --output-format=junit --output-file=ruff.xml --select S324
   - cat ruff.xml || true
   rules:
   - if: ($CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main")

--- a/src/_canary/testspec.py
+++ b/src/_canary/testspec.py
@@ -527,15 +527,16 @@ class _GlobalSpecCache:
             pass
 
         key = path.absolute()
-        h = hashlib.sha256(digest_size=16)
+        h = hashlib.sha256()
         h.update(key.read_bytes())
+        digest = h.digest()[:16]
         root = cls._compute_repo_root(key)
         rel = key.relative_to(root)
 
         with cls._lock:
             cls._repo_root[key] = str(root).encode()
             cls._rel_repo[key] = str(rel).encode()
-            cls._file_hash[key] = h.hexdigest().encode()
+            cls._file_hash[key] = digest.hex().encode()
             return cls._key.setdefault(path, key)
 
     @classmethod

--- a/src/_canary/testspec.py
+++ b/src/_canary/testspec.py
@@ -527,7 +527,7 @@ class _GlobalSpecCache:
             pass
 
         key = path.absolute()
-        h = hashlib.blake2b(digest_size=16)
+        h = hashlib.sha256(digest_size=16)
         h.update(key.read_bytes())
         root = cls._compute_repo_root(key)
         rel = key.relative_to(root)
@@ -551,7 +551,7 @@ class _GlobalSpecCache:
 
 def build_spec_id(spec: BaseSpec) -> str:
     # Hasher is used to build ID
-    hasher = hashlib.blake2b()
+    hasher = hashlib.sha256()
     hasher.update(spec.name.encode())
     parameters = spec.parameters | spec.meta_parameters
     if parameters:

--- a/src/_canary/third_party/programoutput/__init__.py
+++ b/src/_canary/third_party/programoutput/__init__.py
@@ -436,5 +436,5 @@ def hashit(arg, length=15):
     """Create a non-cryptographic hash solely for the purpose of creating a reproducible ID"""
     if isinstance(arg, (list, tuple)):
         arg = " ".join(arg)
-    obj = hashlib.md5(arg.encode("utf-8"))
+    obj = hashlib.sha256(arg.encode("utf-8"))
     return obj.hexdigest()[:length]

--- a/src/_canary/util/hash.py
+++ b/src/_canary/util/hash.py
@@ -6,5 +6,5 @@ import hashlib
 
 
 def hashit(string: str, length: int = 15) -> str:
-    obj = hashlib.md5(string.encode("utf-8"))
+    obj = hashlib.sha256(string.encode("utf-8"))
     return obj.hexdigest()[:length]

--- a/src/_canary/version.py
+++ b/src/_canary/version.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-import re
 import subprocess
 from importlib import metadata as im
 

--- a/src/canary_cmake/cdash/interface.py
+++ b/src/canary_cmake/cdash/interface.py
@@ -102,8 +102,8 @@ class server:
             "stamp": buildstamp,
         }
         if mdf5:
-            md5sum = checksum(hashlib.md5, filename, block_size=8192)
-            params["MD5"] = md5sum
+            sha256sum = checksum(hashlib.sha256, filename, block_size=8192)
+            params["SHA"] = sha256sum
         encoded_params = urlencode(params)
         url = f"{self.baseurl}/submit.php?{encoded_params}"
         logger.info(f"Uploading {os.path.basename(filename)} to {url}")


### PR DESCRIPTION
## Why?
This change is necessary to ensure the application meets FIPS (Federal Information Processing Standards) compliance requirements. MD5 is considered cryptographically broken and is prohibited in FIPS-compliant environments.

## Details
The following modifications were implemented to remove non-compliant hashing algorithms:
- All instances of `MD5` hexdigests across the codebase have been replaced with `SHA256`.
- Updated the CI configuration files for both GitLab and GitHub:
    - Added automated ruff check rule to scan for the usage of non-FIPS compliant hashing algorithms.
    - Reference: https://docs.astral.sh/ruff/rules/hashlib-insecure-hash-function/

## Issue
https://github.com/sandialabs/canary/issues/115