### PR TITLE
attempt to fix slurm PR testing

### DIFF
--- a/docker/slurm/Dockerfile
+++ b/docker/slurm/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9.3
+FROM rockylinux:9
 
 ARG SLURM_VERSION=23.02.7
 ARG SLURM_ROOT=/opt/slurm-${SLURM_VERSION}


### PR DESCRIPTION
Rocky:9.3 is pretty old and some packages appear to be coming in from 9.8 and failing. This commit relaxes the base image version to `9` so that we track the patch updates on the major version and hopefully maintain some stability/robustness